### PR TITLE
docs: format Spring benchmark runtime environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,41 @@ Latest Web Server Benchmark (wrk -t12 -c400 -d10s (after 10s warmup, warmup disc
 - **Gin (Go)**: 165688 req/s | Latency 4.29ms (P90 11.56ms, P99 26.56ms) | RSS 28684KiB | Csw 0
 - **Spring Boot**: 111330 req/s | Latency 3.57ms (P90 4.97ms, P99 7.59ms) | RSS 1330420KiB | Csw 0
 
-Spring runtime env: **openjdk version "25.0.4.1" 2026-08-18 LTS**, Spring Boot **3.2.3** (Spring WebFlux + Reactor Netty on native epoll (G1GC, JDK 25 Leyden AOT, virtual threads disabled)), JVM opts `-Xms1024m -Xmx1024m   -XX:+UseG1GC -XX:GCTimeRatio=99 -XX:G1HeapRegionSize=1m   -XX:+AlwaysPreTouch   -XX:CompileThreshold=1500 -XX:CICompilerCount=4   -Djava.security.egd=file:/dev/urandom   -Djava.net.preferIPv4Stack=true   -Dio.netty.allocator.type=pooled   -Dio.netty.leakDetection.level=disabled   -Dio.netty.buffer.checkBounds=false   -Dio.netty.buffer.checkAccessible=false   -Dreactor.netty.ioWorkerCount=4   -Xlog:gc*:file=/tmp/spring_gc.log:time,uptime,level,tags -XX:+AOTClassLinking -XX:AOTCache=/tmp/spring_bench/app.aot (JEP 483 + JEP 514 single-step AOT)`, warmup/profile: wrk -t12 -c400 -d10s (after 10s warmup, warmup discarded)
+**Spring runtime environment**
+
+- **JDK:** `openjdk version "25.0.4.1" 2026-08-18 LTS`
+- **Spring Boot:** 3.2.3 (Spring WebFlux + Reactor Netty on native epoll)
+- **Garbage collector:** G1GC
+- **AOT:** JDK 25 Leyden AOT (JEP 483 + JEP 514 single-step AOT)
+- **Virtual threads:** disabled
+
+**JVM options**
+
+```text
+-Xms1024m
+-Xmx1024m
+-XX:+UseG1GC
+-XX:GCTimeRatio=99
+-XX:G1HeapRegionSize=1m
+-XX:+AlwaysPreTouch
+-XX:CompileThreshold=1500
+-XX:CICompilerCount=4
+-Djava.security.egd=file:/dev/urandom
+-Djava.net.preferIPv4Stack=true
+-Dio.netty.allocator.type=pooled
+-Dio.netty.leakDetection.level=disabled
+-Dio.netty.buffer.checkBounds=false
+-Dio.netty.buffer.checkAccessible=false
+-Dreactor.netty.ioWorkerCount=4
+-Xlog:gc*:file=/tmp/spring_gc.log:time,uptime,level,tags
+-XX:+AOTClassLinking
+-XX:AOTCache=/tmp/spring_bench/app.aot
+```
+
+**Warmup/profile**
+
+- **Warmup:** 10s (discarded from the results)
+- **Measurement:** `wrk -t12 -c400 -d10s`
 
 ![Web Server Benchmark Trends](docs/webserver-benchmark-trends.svg)
 <!-- WEBSERVER_BENCHMARKS:END -->


### PR DESCRIPTION
## Summary

- Split the Spring runtime environment paragraph in `README.md` into runtime details, JVM options, and warmup/profile sections.
- Display each JVM option on its own line in a fenced `text` block.
- Preserve the supplied version strings, runtime configuration, JVM option values, and measurement profile; benchmark results are unchanged.

## Validation

- `git diff --check` passed.
- Reviewed the diff: only `README.md` is changed.
- No build or benchmark run: this is a documentation-formatting-only change, not a revalidation of the reported runtime or performance.

## Scope note

`scripts/ci/benchmark.py` currently generates this section as a single paragraph. A future benchmark refresh may overwrite this formatting. The generator is intentionally unchanged to keep this PR scoped to the requested `README.md` edit.
