### PR TITLE
fix(ci): preserve readable benchmark runtime reports

### DIFF
--- a/.github/workflows/bsd-kqueue-benchmarks.yml
+++ b/.github/workflows/bsd-kqueue-benchmarks.yml
@@ -15,6 +15,16 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  benchmark-report-tests:
+    name: benchmark report rendering tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Test benchmark report generation
+        run: python3 -m unittest discover -s scripts/ci -p 'test_*.py' -v
+
   bsd-kqueue:
     name: kqueue tests (macOS)
     if: github.event_name != 'push' || !contains(github.event.head_commit.message, '[skip ci]')
@@ -513,7 +523,7 @@ jobs:
             raw_logs/
 
   publish-benchmark-report:
-    needs: [bsd-kqueue, benchmark, web-server-benchmark]
+    needs: [benchmark-report-tests, bsd-kqueue, benchmark, web-server-benchmark]
     if: github.event_name == 'push' && (github.ref == format('refs/heads/{0}', github.event.repository.default_branch) || github.ref == 'refs/heads/dev')
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/README
+++ b/README
@@ -29,7 +29,39 @@ Latest Web Server Benchmark (wrk -t12 -c400 -d10s (after 10s warmup, warmup disc
 - **Gin (Go)**: 147097 req/s | Latency 4.75ms (P90 12.66ms, P99 30.51ms) | RSS 29680KiB | Csw 0
 - **Spring Boot**: 100637 req/s | Latency 3.93ms (P90 5.56ms, P99 8.85ms) | RSS 1311800KiB | Csw 0
 
-Spring runtime env: **openjdk version "25.0.4.1" 2026-08-18 LTS**, Spring Boot **3.2.3** (Spring WebFlux + Reactor Netty on native epoll (G1GC, JDK 25 Leyden AOT, virtual threads disabled)), JVM opts `-Xms1024m -Xmx1024m   -XX:+UseG1GC -XX:GCTimeRatio=99 -XX:G1HeapRegionSize=1m   -XX:+AlwaysPreTouch   -XX:CompileThreshold=1500 -XX:CICompilerCount=4   -Djava.security.egd=file:/dev/urandom   -Djava.net.preferIPv4Stack=true   -Dio.netty.allocator.type=pooled   -Dio.netty.leakDetection.level=disabled   -Dio.netty.buffer.checkBounds=false   -Dio.netty.buffer.checkAccessible=false   -Dreactor.netty.ioWorkerCount=4   -Xlog:gc*:file=/tmp/spring_gc.log:time,uptime,level,tags -XX:+AOTClassLinking -XX:AOTCache=/tmp/spring_bench/app.aot (JEP 483 + JEP 514 single-step AOT)`, warmup/profile: wrk -t12 -c400 -d10s (after 10s warmup, warmup discarded)
+**Spring runtime environment**
+
+- **JDK:** `openjdk version "25.0.4.1" 2026-08-18 LTS`
+- **Spring Boot:** 3.2.3
+- **Stack:** Spring WebFlux + Reactor Netty on native epoll (G1GC, JDK 25 Leyden AOT, virtual threads disabled)
+- **Virtual threads:** disabled
+
+**JVM options**
+
+```text
+-Xms1024m
+-Xmx1024m
+-XX:+UseG1GC
+-XX:GCTimeRatio=99
+-XX:G1HeapRegionSize=1m
+-XX:+AlwaysPreTouch
+-XX:CompileThreshold=1500
+-XX:CICompilerCount=4
+-Djava.security.egd=file:/dev/urandom
+-Djava.net.preferIPv4Stack=true
+-Dio.netty.allocator.type=pooled
+-Dio.netty.leakDetection.level=disabled
+-Dio.netty.buffer.checkBounds=false
+-Dio.netty.buffer.checkAccessible=false
+-Dreactor.netty.ioWorkerCount=4
+-Xlog:gc*:file=/tmp/spring_gc.log:time,uptime,level,tags
+-XX:+AOTClassLinking
+-XX:AOTCache=/tmp/spring_bench/app.aot (JEP 483 + JEP 514 single-step AOT)
+```
+
+**Warmup/profile**
+
+wrk -t12 -c400 -d10s (after 10s warmup, warmup discarded)
 
 ![Web Server Benchmark Trends](docs/webserver-benchmark-trends.svg)
 <!-- WEBSERVER_BENCHMARKS:END -->

--- a/README.md
+++ b/README.md
@@ -25,7 +25,39 @@ Latest Web Server Benchmark (wrk -t12 -c400 -d10s (after 10s warmup, warmup disc
 - **Gin (Go)**: 147097 req/s | Latency 4.75ms (P90 12.66ms, P99 30.51ms) | RSS 29680KiB | Csw 0
 - **Spring Boot**: 100637 req/s | Latency 3.93ms (P90 5.56ms, P99 8.85ms) | RSS 1311800KiB | Csw 0
 
-Spring runtime env: **openjdk version "25.0.4.1" 2026-08-18 LTS**, Spring Boot **3.2.3** (Spring WebFlux + Reactor Netty on native epoll (G1GC, JDK 25 Leyden AOT, virtual threads disabled)), JVM opts `-Xms1024m -Xmx1024m   -XX:+UseG1GC -XX:GCTimeRatio=99 -XX:G1HeapRegionSize=1m   -XX:+AlwaysPreTouch   -XX:CompileThreshold=1500 -XX:CICompilerCount=4   -Djava.security.egd=file:/dev/urandom   -Djava.net.preferIPv4Stack=true   -Dio.netty.allocator.type=pooled   -Dio.netty.leakDetection.level=disabled   -Dio.netty.buffer.checkBounds=false   -Dio.netty.buffer.checkAccessible=false   -Dreactor.netty.ioWorkerCount=4   -Xlog:gc*:file=/tmp/spring_gc.log:time,uptime,level,tags -XX:+AOTClassLinking -XX:AOTCache=/tmp/spring_bench/app.aot (JEP 483 + JEP 514 single-step AOT)`, warmup/profile: wrk -t12 -c400 -d10s (after 10s warmup, warmup discarded)
+**Spring runtime environment**
+
+- **JDK:** `openjdk version "25.0.4.1" 2026-08-18 LTS`
+- **Spring Boot:** 3.2.3
+- **Stack:** Spring WebFlux + Reactor Netty on native epoll (G1GC, JDK 25 Leyden AOT, virtual threads disabled)
+- **Virtual threads:** disabled
+
+**JVM options**
+
+```text
+-Xms1024m
+-Xmx1024m
+-XX:+UseG1GC
+-XX:GCTimeRatio=99
+-XX:G1HeapRegionSize=1m
+-XX:+AlwaysPreTouch
+-XX:CompileThreshold=1500
+-XX:CICompilerCount=4
+-Djava.security.egd=file:/dev/urandom
+-Djava.net.preferIPv4Stack=true
+-Dio.netty.allocator.type=pooled
+-Dio.netty.leakDetection.level=disabled
+-Dio.netty.buffer.checkBounds=false
+-Dio.netty.buffer.checkAccessible=false
+-Dreactor.netty.ioWorkerCount=4
+-Xlog:gc*:file=/tmp/spring_gc.log:time,uptime,level,tags
+-XX:+AOTClassLinking
+-XX:AOTCache=/tmp/spring_bench/app.aot (JEP 483 + JEP 514 single-step AOT)
+```
+
+**Warmup/profile**
+
+wrk -t12 -c400 -d10s (after 10s warmup, warmup discarded)
 
 ![Web Server Benchmark Trends](docs/webserver-benchmark-trends.svg)
 <!-- WEBSERVER_BENCHMARKS:END -->

--- a/scripts/ci/benchmark.py
+++ b/scripts/ci/benchmark.py
@@ -175,14 +175,26 @@ def render() -> None:
     )
     ws_env = ws_latest.get("spring_env", {}) or {}
     if ws_env:
-        ws_stack = ws_env.get('stack')
-        ws_stack_part = f" ({ws_stack})" if ws_stack else ""
-        ws_vt = ws_env.get('virtual_threads')
-        ws_vt_part = f", virtual threads **{'on' if ws_vt else 'off'}**" if ws_vt else ""
         ws_summary += (
-            f"\nSpring runtime env: **{ws_env.get('java_version','n/a')}**, Spring Boot **{ws_env.get('spring_boot_version','n/a')}**{ws_stack_part}"
-            f"{ws_vt_part}, "
-            f"JVM opts `{ws_env.get('jvm_opts','n/a')}`, warmup/profile: {ws_latest.get('wrk_profile','n/a')}\n"
+            "\n**Spring runtime environment**\n\n"
+            f"- **JDK:** `{ws_env.get('java_version','n/a')}`\n"
+            f"- **Spring Boot:** {ws_env.get('spring_boot_version','n/a')}\n"
+        )
+        if ws_env.get('stack'):
+            ws_summary += f"- **Stack:** {ws_env['stack']}\n"
+        ws_vt = ws_env.get('virtual_threads')
+        if ws_vt is not None:
+            ws_summary += f"- **Virtual threads:** {'enabled' if ws_vt else 'disabled'}\n"
+        # Break before options, not within quoted values or historical AOT notes.
+        # This is display formatting only; retain the recorded option spelling.
+        jvm_opts = re.sub(
+            r'''("(?:\\.|[^"\\])*"|'[^']*')|\s+(?=-)''',
+            lambda match: match.group(1) if match.group(1) is not None else "\n",
+            ws_env.get('jvm_opts', 'n/a').strip(),
+        )
+        ws_summary += (
+            f"\n**JVM options**\n\n```text\n{jvm_opts}\n```\n"
+            f"\n**Warmup/profile**\n\n{ws_latest.get('wrk_profile','n/a')}\n"
         )
     ws_summary += f"\n![Web Server Benchmark Trends](docs/webserver-benchmark-trends.svg)"
     if README.exists(): replace(README, "<!-- WEBSERVER_BENCHMARKS:START -->", "<!-- WEBSERVER_BENCHMARKS:END -->", ws_summary)

--- a/scripts/ci/test_benchmark.py
+++ b/scripts/ci/test_benchmark.py
@@ -1,0 +1,130 @@
+"""Regression tests for the report CLI; no build or benchmark dependencies."""
+import json
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+SCRIPT = Path(__file__).with_name("benchmark.py")
+PROFILE = "wrk -t12 -c400 -d10s (after 10s warmup, warmup discarded)"
+OPTIONS = (
+    "-Xms1024m -Xmx1024m   -XX:+UseG1GC\t"
+    "-Xlog:gc*:file=/tmp/spring_gc.log:time,uptime,level,tags "
+    "-XX:AOTCache=/tmp/spring_bench/app.aot (JEP 483 + JEP 514 single-step AOT)"
+)
+ENV = {
+    "java_version": 'openjdk version "25.0.4.1" 2026-08-18 LTS',
+    "spring_boot_version": "3.2.3",
+    "stack": "Spring WebFlux + Reactor Netty on native epoll (G1GC, JDK 25 Leyden AOT)",
+    "jvm_opts": OPTIONS,
+    "virtual_threads": False,
+}
+START = "<!-- WEBSERVER_BENCHMARKS:START -->"
+END = "<!-- WEBSERVER_BENCHMARKS:END -->"
+
+
+class BenchmarkRenderTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        script = self.root / "scripts/ci/benchmark.py"
+        script.parent.mkdir(parents=True)
+        shutil.copyfile(SCRIPT, script)
+        (self.root / "benchmarks").mkdir()
+        (self.root / "benchmarks/db.json").write_text("[]\n")
+        block = f"{START}\nold report\n{END}\n"
+        (self.root / "README").write_text(
+            "<!-- BENCHMARKS:START -->\nold\n<!-- BENCHMARKS:END -->\n" + block
+        )
+        (self.root / "README.md").write_text("# Before\n\n" + block + "\n# After\n")
+        (self.root / "ROADMAP.md").write_text(
+            "<!-- CI-BENCHMARKS:START -->\nold\n<!-- CI-BENCHMARKS:END -->\n"
+        )
+
+    def render(self, env=ENV):
+        row = {"cwist_rps": 12345, "spring_rps": 6789, "wrk_profile": PROFILE}
+        if env is not None:
+            row["spring_env"] = env
+        history = self.root / "benchmarks/webserver.json"
+        history.write_text(json.dumps([row]) + "\n")
+        before = history.read_bytes()
+        subprocess.run(
+            [sys.executable, str(self.root / "scripts/ci/benchmark.py"), "render"],
+            check=True, capture_output=True, text=True,
+        )
+        self.assertEqual(history.read_bytes(), before)
+        readme = (self.root / "README.md").read_text()
+        plain = (self.root / "README").read_text()
+        self.assertEqual(self.block(readme), self.block(plain))
+        self.assertTrue(readme.startswith("# Before\n\n" + START))
+        self.assertTrue(readme.endswith(END + "\n\n# After\n"))
+        self.assertIn("**CWIST (classic pool)**: 12345 req/s", readme)
+        self.assertIn("**Spring Boot**: 6789 req/s", readme)
+        return readme
+
+    @staticmethod
+    def block(text):
+        return text.split(START, 1)[1].split(END, 1)[0]
+
+    def test_runtime_fields_and_profile_are_separate_markdown_sections(self):
+        readme = self.render()
+        self.assertIn("\n**Spring runtime environment**\n\n", readme)
+        self.assertIn(f"- **JDK:** `{ENV['java_version']}`\n", readme)
+        self.assertIn("- **Spring Boot:** 3.2.3\n", readme)
+        self.assertIn(f"- **Stack:** {ENV['stack']}\n", readme)
+        self.assertIn(f"\n**Warmup/profile**\n\n{PROFILE}\n", readme)
+        self.assertNotIn("Spring runtime env:", readme)
+
+    def test_jvm_options_have_individual_lines_without_losing_annotation(self):
+        readme = self.render()
+        expected = (
+            "\n**JVM options**\n\n```text\n"
+            "-Xms1024m\n-Xmx1024m\n-XX:+UseG1GC\n"
+            "-Xlog:gc*:file=/tmp/spring_gc.log:time,uptime,level,tags\n"
+            "-XX:AOTCache=/tmp/spring_bench/app.aot (JEP 483 + JEP 514 single-step AOT)\n"
+            "```\n"
+        )
+        self.assertIn(expected, readme)
+
+    def test_quoted_option_values_remain_intact(self):
+        options = '-Dlabel="value -with spaces"  -Dother=\'keep -this too\' -Xmx1024m'
+        readme = self.render({**ENV, "jvm_opts": options})
+        self.assertIn(
+            '```text\n-Dlabel="value -with spaces"\n-Dother=\'keep -this too\'\n-Xmx1024m\n```',
+            readme,
+        )
+
+    def test_virtual_threads_false_is_explicit(self):
+        self.assertIn("- **Virtual threads:** disabled\n", self.render())
+
+    def test_virtual_threads_true_is_explicit(self):
+        readme = self.render({**ENV, "virtual_threads": True})
+        self.assertIn("- **Virtual threads:** enabled\n", readme)
+
+    def test_missing_optional_fields_do_not_invent_runtime_settings(self):
+        readme = self.render({"java_version": "test JDK"})
+        self.assertIn("- **Spring Boot:** n/a\n", readme)
+        self.assertIn("```text\nn/a\n```", readme)
+        self.assertNotIn("- **Stack:**", readme)
+        self.assertNotIn("- **Virtual threads:**", readme)
+
+    def test_no_environment_omits_runtime_section(self):
+        for env in (None, {}):
+            with self.subTest(env=env):
+                self.assertNotIn("**Spring runtime environment**", self.render(env))
+
+    def test_repeated_render_is_byte_identical(self):
+        self.render()
+        outputs = ["README", "README.md", "ROADMAP.md", "docs/benchmark-trends.svg",
+                   "docs/webserver-benchmark-trends.svg"]
+        first = {name: (self.root / name).read_bytes() for name in outputs}
+        self.render()
+        self.assertEqual(first, {name: (self.root / name).read_bytes() for name in outputs})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fix benchmark report generation so CI preserves readable Spring runtime details. Follow-up to #22.

## Root cause

The `publish-benchmark-report` job in `.github/workflows/bsd-kqueue-benchmarks.yml` runs `python3 scripts/ci/benchmark.py render` and commits the generated documentation. The renderer concatenated the JDK, Spring stack, JVM options, and measurement profile into one paragraph with one long inline-code span. Bot commit `ad2def219dbf024dc7016cb25f7564c42822eec2` overwrote the formatting merged in #22.

## Changes

- Render runtime fields, JVM options, and warmup/profile as separate Markdown sections.
- Put JVM options on separate lines in a fenced text block; preserve quoted values and recorded AOT annotations.
- Render explicit false virtual-thread settings as disabled without inventing missing settings.
- Regenerate both README files from the existing recorded history.
- Add dependency-free CLI regression tests and a read-only Actions test job. Report publication now depends on that job.

No benchmark measurements, history JSON, SVGs, roadmap, or runtime execution settings changed.

## Validation

- Eight unittest regression tests pass. Six fail against the old renderer, confirming regression sensitivity.
- Real-history rendering matches the new README sections and is byte-identical on repeat execution.
- Existing option tokens and throughput lines are preserved.
- GitHub Markdown API confirms all 18 JVM options remain separate lines in a preformatted code block.
- Workflow YAML parsing, publishing-dependency assertions, and `git diff --cached --check` pass.
- Independent staged-diff security and logic review passes with no blocking findings.

Full native builds and fresh performance benchmarks were not run locally; this change only affects report formatting and its tests. Remote Actions results should be checked separately.
