### PR TITLE
fix: make sanitizer async and worker teardown safe

### DIFF
--- a/include/cwist/net/http/async.h
+++ b/include/cwist/net/http/async.h
@@ -53,22 +53,41 @@ typedef struct cwist_async cwist_async;
  * Call from inside a route handler and return immediately afterwards; the
  * handler must not touch @p req or @p res after this call.  Ownership of
  * both objects transfers to the returned handle.
+ * The framework owns the handle until completion; a single producer needs
+ * no explicit release. Before publishing it to competing producers (including
+ * a producer that can lose to a timeout), retain a reference for each producer
+ * while the handle is still live, then release each after its final attempt.
  * @return Handle to complete later, or NULL on allocation failure (the
  * framework falls back to answering whatever the handler wrote).
  */
 cwist_async *cwist_async_defer(cwist_http_request *req, cwist_http_response *res);
 
 /**
+ * @brief Retain a live handle for a producer that may outlive completion.
+ * Must be called while the caller already holds a reference, or before the
+ * dispatch handoff can complete. It cannot resurrect an expired handle.
+ * Returns @p a (NULL is accepted). Each retain requires one release.
+ */
+cwist_async *cwist_async_retain(cwist_async *a);
+
+/**
+ * @brief Release a reference acquired with cwist_async_retain().
+ * Does not complete or abort the exchange. NULL is accepted.
+ */
+void cwist_async_release(cwist_async *a);
+
+/**
  * @brief Answer with a 504 Gateway Timeout if the exchange is still pending
  * after @p ms milliseconds.  The timeout routes through the same completion
- * path as a normal response.  Default is no timeout (0).
+ * path as a normal response. The timer holds its own handle reference until
+ * its callback runs, even if another producer wins. Default is no timeout (0).
  */
 void cwist_async_set_timeout(cwist_async *a, uint64_t ms);
 
 /**
  * @brief Complete the exchange with a simple body response.
  * Thread-safe and one-shot: the first of respond/respond_with/abort wins,
- * later calls return false.  @p body is copied.
+ * later calls on a retained, live handle return false. @p body is copied.
  */
 bool cwist_async_respond(cwist_async *a, cwist_http_status_t status, const char *content_type, const void *body, size_t len);
 

--- a/src/net/http/async.c
+++ b/src/net/http/async.c
@@ -36,6 +36,7 @@ enum cwist_async_state {
 };
 
 struct cwist_async {
+    _Atomic size_t refs;          /* Completion plus retained producers/timers. */
     _Atomic int state;
     _Atomic bool ack;             /* Dispatch path observed the handoff. */
     cwist_http_request *req;
@@ -80,6 +81,7 @@ cwist_async *cwist_async_defer(cwist_http_request *req, cwist_http_response *res
     cwist_async *a = cwist_alloc(sizeof(*a));
     if (!a) return NULL;
     memset(a, 0, sizeof(*a));
+    atomic_init(&a->refs, 1);
     atomic_init(&a->state, CWIST_ASYNC_ST_PENDING);
     atomic_init(&a->ack, false);
     a->req = req;
@@ -109,6 +111,17 @@ cwist_async *cwist_async_defer(cwist_http_request *req, cwist_http_response *res
     res->async = a;
     res->deferred = true;
     return a;
+}
+
+cwist_async *cwist_async_retain(cwist_async *a) {
+    if (a) atomic_fetch_add_explicit(&a->refs, 1, memory_order_relaxed);
+    return a;
+}
+
+void cwist_async_release(cwist_async *a) {
+    if (a && atomic_fetch_sub_explicit(&a->refs, 1, memory_order_acq_rel) == 1) {
+        cwist_free(a);
+    }
 }
 
 void cwist_async_dispatch_ack(cwist_async *a) {
@@ -142,7 +155,7 @@ static void cwist_async_complete(cwist_async *a) {
         cwist_h2_async_queue_enqueue(a->h2_queue, a->h2_stream_id, a->req,
                                      a->final_res, a->res, a->final_res_owned);
         cwist_h2_async_queue_release(a->h2_queue);
-        cwist_free(a);
+        cwist_async_release(a);
         return;
     }
 
@@ -184,7 +197,7 @@ static void cwist_async_complete(cwist_async *a) {
     if (a->final_res_owned) cwist_http_response_destroy(res);
     cwist_http_response_destroy(a->res);
     cwist_http_request_destroy(a->req);
-    cwist_free(a);
+    cwist_async_release(a);
 }
 
 static void cwist_async_reactor_complete(void *ctx) {
@@ -210,20 +223,27 @@ static void cwist_async_timeout_sched_init(void) {
 
 static void cwist_async_timeout_job(void *arg) {
     cwist_async *a = (cwist_async *)arg;
-    if (!cwist_async_claim(a)) return; /* A real response beat the timeout. */
+    if (!cwist_async_claim(a)) {
+        cwist_async_release(a); /* A real response beat the timeout. */
+        return;
+    }
     cwist_http_response *res = a->res;
     res->status_code = CWIST_HTTP_GATEWAY_TIMEOUT;
     cwist_sstring_assign(res->status_text, (char *)"Gateway Timeout");
     cwist_sstring_assign(res->body, (char *)"Gateway Timeout");
     cwist_http_header_add(&res->headers, "Content-Type", "text/plain");
     cwist_async_finish(a);
+    cwist_async_release(a);
 }
 
 void cwist_async_set_timeout(cwist_async *a, uint64_t ms) {
     if (!a || ms == 0) return;
     pthread_once(&g_timeout_once, cwist_async_timeout_sched_init);
     if (!g_timeout_sched) return;
-    cwist_scheduler_schedule(g_timeout_sched, cwist_async_timeout_job, a, ms);
+    cwist_async_retain(a);
+    if (!cwist_scheduler_schedule(g_timeout_sched, cwist_async_timeout_job, a, ms)) {
+        cwist_async_release(a);
+    }
 }
 
 /* --- Completion API ------------------------------------------------------ */

--- a/src/sys/app/app.c
+++ b/src/sys/app/app.c
@@ -3370,7 +3370,7 @@ static void *h3_server_thread_func(void *arg) {
  * @brief Initialize runtime services and enter the HTTP or HTTPS server loop.
  * @param app Application instance to run.
  * @param port TCP port to bind.
- * @return 0 on success, or -1 when initialization or bind fails.
+ * @return 0 on success, or -1 when initialization, bind, or worker shutdown fails.
  */
 int cwist_app_listen(cwist_app *app, int port) {
     // Ignore SIGPIPE
@@ -3397,9 +3397,6 @@ int cwist_app_listen(cwist_app *app, int port) {
         fprintf(stderr, "Assertion failed: Cannot use both ephemeral HTTP/3 and TLS HTTP/3 simultaneously on the same port.\n");
         abort();
     }
-
-    // Initialize Memory Manager (structure only; thread is started per-process after fork)
-    cwist_mem_init(app);
 
     /* Create the shared TCP listen socket before forking workers.
      * With SO_REUSEPORT each worker process gets its own accept queue and the
@@ -3488,6 +3485,11 @@ int cwist_app_listen(cwist_app *app, int port) {
         }
     }
 
+    /* The static cache owns a libttak cleanup thread as well as the watcher.
+     * Initialize it only after all worker forks so no child inherits mutexes
+     * or a pthread handle whose owning thread exists only in the parent. */
+    cwist_mem_init(app);
+
     // Per-process threads start here.  Each worker gets its own watcher and
     // HTTP/3 thread, so fork-after-thread deadlock is avoided.
     if (app->mem_manager) {
@@ -3560,6 +3562,7 @@ int cwist_app_listen(cwist_app *app, int port) {
         sleep(g_cwist_drain_timeout_sec);
     }
 
+    int worker_result = 0;
     /* Parent process reaps worker children so they do not become zombies. */
     if (!is_worker_child && workers > 1) {
         /* SIGTERM is delivered to the supervisor only.  Ask every worker to
@@ -3570,13 +3573,24 @@ int cwist_app_listen(cwist_app *app, int port) {
         }
         for (size_t i = 0; i < worker_count; i++) {
             int status;
-            wait(&status);
+            pid_t reaped;
+            do {
+                reaped = waitpid(worker_pids[i], &status, 0);
+            } while (reaped < 0 && errno == EINTR);
+            if (reaped < 0) {
+                perror("waitpid worker");
+                worker_result = -1;
+            } else if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+                fprintf(stderr, "Worker %d exited abnormally (status=%d)\n",
+                        (int)worker_pids[i], status);
+                worker_result = -1;
+            }
         }
     }
 
     printf("[CWIST] Shutdown complete.\n");
 
-    return 0;
+    return worker_result;
 }
 
 static char cwist_swagger_json_path[512] = "openapi.json";

--- a/tests/test_async_defer.c
+++ b/tests/test_async_defer.c
@@ -29,15 +29,27 @@
 
 /* --- Server side --------------------------------------------------------- */
 
+static _Atomic int g_response_jobs = 0;
+static _Atomic int g_response_done = 0;
+static _Atomic int g_response_wins = 0;
+
 static void respond_later_job(void *arg) {
     cwist_async *a = (cwist_async *)arg;
-    cwist_async_respond(a, CWIST_HTTP_OK, "text/plain", "deferred-body", 13);
+    if (cwist_async_respond(a, CWIST_HTTP_OK, "text/plain", "deferred-body", 13)) {
+        atomic_fetch_add(&g_response_wins, 1);
+    }
+    cwist_async_release(a);
+    atomic_fetch_add(&g_response_done, 1);
 }
 
 static void schedule_respond(cwist_http_request *req, cwist_async *a, uint64_t delay_ms) {
     cwist_scheduler_t *s = cwist_app_get_scheduler(req->app);
+    cwist_async_retain(a);
     if (!s || !cwist_scheduler_schedule(s, respond_later_job, a, delay_ms)) {
+        cwist_async_release(a);
         cwist_async_abort(a, CWIST_HTTP_INTERNAL_ERROR);
+    } else {
+        atomic_fetch_add(&g_response_jobs, 1);
     }
 }
 
@@ -69,13 +81,36 @@ static void timeout_handler(cwist_http_request *req, cwist_http_response *res) {
     /* Never respond: the timeout must route a 504. */
 }
 
+static void response_before_timeout_handler(cwist_http_request *req, cwist_http_response *res) {
+    cwist_async *a = cwist_async_defer(req, res);
+    if (!a) {
+        res->status_code = CWIST_HTTP_INTERNAL_ERROR;
+        return;
+    }
+    cwist_async_set_timeout(a, 250);
+    schedule_respond(req, a, 25);
+}
+
+static void timeout_before_response_handler(cwist_http_request *req, cwist_http_response *res) {
+    cwist_async *a = cwist_async_defer(req, res);
+    if (!a) {
+        res->status_code = CWIST_HTTP_INTERNAL_ERROR;
+        return;
+    }
+    cwist_async_set_timeout(a, 25);
+    schedule_respond(req, a, 250);
+}
+
 static _Atomic int g_race_wins = 0;
+static _Atomic int g_race_done = 0;
 
 static void *race_thread(void *arg) {
     cwist_async *a = (cwist_async *)arg;
     if (cwist_async_respond(a, CWIST_HTTP_OK, "text/plain", "race-winner", 11)) {
         atomic_fetch_add(&g_race_wins, 1);
     }
+    cwist_async_release(a);
+    atomic_fetch_add(&g_race_done, 1);
     return NULL;
 }
 
@@ -86,8 +121,13 @@ static void race_handler(cwist_http_request *req, cwist_http_response *res) {
         return;
     }
     pthread_t t1, t2;
-    pthread_create(&t1, NULL, race_thread, a);
-    pthread_create(&t2, NULL, race_thread, a);
+    /* Acquire both producer references before either thread can complete. */
+    cwist_async_retain(a);
+    cwist_async_retain(a);
+    if (pthread_create(&t1, NULL, race_thread, a) != 0 ||
+        pthread_create(&t2, NULL, race_thread, a) != 0) {
+        _exit(1);
+    }
     pthread_detach(t1);
     pthread_detach(t2);
 }
@@ -114,6 +154,13 @@ static void respond_big_job(void *arg) {
 }
 
 static void bigdefer_handler(cwist_http_request *req, cwist_http_response *res) {
+    /* Force backpressure at the sender, not with a tiny client receive
+     * window: draining queued TCP bytes must not outlast keep-alive. */
+    int sndbuf = 4096;
+    if (setsockopt(req->client_fd, SOL_SOCKET, SO_SNDBUF, &sndbuf, sizeof(sndbuf)) < 0) {
+        res->status_code = CWIST_HTTP_INTERNAL_ERROR;
+        return;
+    }
     cwist_async *a = cwist_async_defer(req, res);
     if (!a) {
         res->status_code = CWIST_HTTP_INTERNAL_ERROR;
@@ -211,6 +258,49 @@ static bool has_code(const char *buf, const char *code) {
     if (!(cond)) { fprintf(stderr, "FAIL: %s\n", msg); failures++; } \
 } while (0)
 
+/* Synchronous completion destroys req/res before the losing calls run. */
+static int test_retained_completion(void) {
+    int failures = 0;
+    int sockets[2];
+    if (socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) < 0) return 1;
+    cwist_http_request *req = cwist_http_request_create();
+    cwist_http_response *res = cwist_http_response_create();
+    if (!req || !res) {
+        cwist_http_request_destroy(req);
+        cwist_http_response_destroy(res);
+        close(sockets[0]);
+        close(sockets[1]);
+        return 1;
+    }
+    req->client_fd = sockets[0];
+    req->keep_alive = false;
+    cwist_async *a = cwist_async_defer(req, res);
+    if (!a) {
+        cwist_http_request_destroy(req);
+        cwist_http_response_destroy(res);
+        close(sockets[0]);
+        close(sockets[1]);
+        return 1;
+    }
+    CHECK(cwist_async_retain(a) == a, "retain returns the live handle");
+    cwist_async_dispatch_ack(a);
+    CHECK(cwist_async_respond(a, CWIST_HTTP_OK, "text/plain", "ok", 2),
+          "first synchronous completion wins");
+    CHECK(!cwist_async_respond(a, CWIST_HTTP_OK, NULL, NULL, 0),
+          "late respond safely loses after completion");
+    CHECK(!cwist_async_abort(a, CWIST_HTTP_INTERNAL_ERROR),
+          "late abort safely loses after completion");
+    cwist_http_response *loser = cwist_http_response_create();
+    CHECK(loser != NULL, "allocate losing caller-owned response");
+    if (loser) {
+        CHECK(!cwist_async_respond_with(a, loser), "late respond_with safely loses");
+        cwist_http_response_destroy(loser);
+    }
+    cwist_async_release(a);
+    close(sockets[1]);
+    return failures;
+}
+
 int main(void) {
     printf("Testing deferred responses (async handlers)...\n");
 
@@ -230,6 +320,8 @@ int main(void) {
         cwist_app_get(app, "/defer200", defer200_handler);
         cwist_app_get(app, "/slow250", slow250_handler);
         cwist_app_get(app, "/timeout", timeout_handler);
+        cwist_app_get(app, "/response-before-timeout", response_before_timeout_handler);
+        cwist_app_get(app, "/timeout-before-response", timeout_before_response_handler);
         cwist_app_get(app, "/race", race_handler);
         cwist_app_get(app, "/hello", hello_handler);
         cwist_app_get(app, "/bigdefer", bigdefer_handler);
@@ -239,8 +331,15 @@ int main(void) {
         g_cwist_drain_timeout_sec = 1;
         int rc = cwist_app_listen(app, TEST_PORT);
         int wins = atomic_load(&g_race_wins);
+        int done = atomic_load(&g_race_done);
+        int jobs = atomic_load(&g_response_jobs);
+        int responses_done = atomic_load(&g_response_done);
+        int responses_won = atomic_load(&g_response_wins);
         cwist_app_destroy(app);
-        _exit(rc == 0 && wins <= 1 ? 0 : 1);
+        /* Every producer must have finished, and exactly the response queued
+         * after its timeout must have lost the completion race. */
+        _exit(rc == 0 && wins == 1 && done == 2 && jobs == responses_done &&
+              responses_won == jobs - 1 ? 0 : 1);
     }
 
     usleep(400000);
@@ -308,6 +407,27 @@ int main(void) {
         }
     }
 
+    /* Check both timeout/response orderings, including each late callback. */
+    {
+        const char *paths[] = { "/response-before-timeout", "/timeout-before-response" };
+        const char *codes[] = { "200", "504" };
+        for (size_t i = 0; i < 2; i++) {
+            struct client_conn c = { .fd = connect_to_server(), .pending_len = 0 };
+            CHECK(c.fd >= 0, "connect for response/timeout competition");
+            if (c.fd < 0) continue;
+            char request[256];
+            snprintf(request, sizeof(request), "GET %s HTTP/1.1\r\nHost: localhost\r\n\r\n", paths[i]);
+            send_all(c.fd, request);
+            int n = read_one_response(&c, buf, sizeof(buf));
+            CHECK(n > 0 && has_code(buf, codes[i]), "expected response/timeout winner");
+            usleep(350000);
+            send_all(c.fd, "GET /hello HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
+            n = read_one_response(&c, buf, sizeof(buf));
+            CHECK(n > 0 && strstr(buf, "second-ok"), "late callback leaves connection reusable");
+            close(c.fd);
+        }
+    }
+
     /* 5. One-shot race: two threads respond; exactly one response arrives. */
     {
         struct client_conn c = { .fd = connect_to_server(), .pending_len = 0 };
@@ -351,8 +471,6 @@ int main(void) {
         int fd = connect_to_server();
         CHECK(fd >= 0, "connect for slow-client park");
         if (fd >= 0) {
-            int rcvbuf = 4096;
-            setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &rcvbuf, sizeof(rcvbuf));
             send_all(fd, "GET /bigdefer HTTP/1.1\r\nHost: localhost\r\n\r\n");
             /* Do not read: the server's send buffer fills and the deferred
              * completion must park instead of blocking a worker/reactor. */
@@ -412,6 +530,7 @@ int main(void) {
         failures++;
     }
 
+    failures += test_retained_completion();
     if (failures == 0) {
         printf("All async defer tests passed.\n");
         return 0;

--- a/tests/test_static_and_range.c
+++ b/tests/test_static_and_range.c
@@ -17,6 +17,7 @@
 #include <arpa/inet.h>
 #include <fcntl.h>
 #include <ctype.h>
+#include <errno.h>
 
 #define TEST_PORT 19998
 #define TEST_HOST "127.0.0.1"
@@ -137,8 +138,13 @@ int main(void) {
     }
 
     if (pid == 0) {
-        /* Child: run server */
-        setenv("CWIST_C1M_MODE", "false", 1);
+        /* Exercise static-cache creation and teardown across a worker fork,
+         * regardless of the runner's CPU count or inherited environment. */
+        if (setenv("CWIST_WORKERS", "2", 1) != 0 ||
+            setenv("CWIST_C1M_MODE", "false", 1) != 0) {
+            perror("setenv");
+            _exit(1);
+        }
         cwist_app *app = cwist_app_create();
         if (!app) {
             fprintf(stderr, "Failed to create app\n");
@@ -246,18 +252,41 @@ int main(void) {
     }
 
     /* Cleanup */
-    kill(pid, SIGTERM);
-    int status;
+    if (kill(pid, SIGTERM) < 0 && errno != ESRCH) {
+        perror("kill SIGTERM");
+        failures++;
+    }
+    int status = 0;
     int waited = 0;
+    pid_t reaped = 0;
     while (waited < 50) {
-        pid_t r = waitpid(pid, &status, WNOHANG);
-        if (r == pid) break;
+        reaped = waitpid(pid, &status, WNOHANG);
+        if (reaped == pid) break;
+        if (reaped < 0) {
+            if (errno == EINTR) continue;
+            perror("waitpid");
+            failures++;
+            break;
+        }
         usleep(100000);
         waited++;
     }
     if (waited >= 50) {
-        kill(pid, SIGKILL);
-        waitpid(pid, &status, 0);
+        fprintf(stderr, "FAIL: Server did not exit in time, sending SIGKILL\n");
+        failures++;
+        if (kill(pid, SIGKILL) < 0 && errno != ESRCH) {
+            perror("kill SIGKILL");
+        }
+        do {
+            reaped = waitpid(pid, &status, 0);
+        } while (reaped < 0 && errno == EINTR);
+        if (reaped < 0) {
+            perror("waitpid after SIGKILL");
+        }
+    }
+    if (reaped == pid && (!WIFEXITED(status) || WEXITSTATUS(status) != 0)) {
+        fprintf(stderr, "FAIL: Server exited abnormally (status=%d)\n", status);
+        failures++;
     }
 
     unlink(index_path);


### PR DESCRIPTION
## Summary

Fix the Address/UBSan failures in the sanitizer job by correcting two real lifetime issues:

- Initialize the static-file memory tree after worker forks so libttak's cleanup thread and synchronization state are never inherited by forked workers.
- Give deferred async handles explicit retained references for delayed producers, timeout callbacks, and concurrent responders. Late losers now safely return `false` instead of accessing freed memory.

The static/range test now exercises two workers and fails on abnormal server exit, wait errors, or shutdown timeout. The async test covers both response-vs-timeout orderings, waits for competing callbacks, and applies backpressure at the server send buffer without weakening response/keep-alive assertions.

## Root cause

The failing static test inherited a libttak cleanup pthread across CWIST's worker fork and later attempted to join the non-existent thread in the child. The async test allowed a losing producer to call `cwist_async_claim()` after the winning completion had freed the handle.

## Verification

- Ubuntu 24.04 x86_64, GCC 13.3, `SANITIZE=address,undefined`, `WERROR=1`.
- `make SANITIZE=address,undefined WERROR=1 test_static_and_range test_async_defer` — passed; C1M and classic async modes passed.
- `make SANITIZE=address,undefined WERROR=1 test` — passed; all tests including stress/ab, async defer, and proto generation passed.
- Five repeated sanitizer runs each for static/range and async defer — 10/10 passed.
- Independent worker-shutdown harness — 10/10 scenarios passed, including real EINTR, nonzero/signaled workers, unrelated child preservation, and ECHILD handling.
- `git diff --check` — passed.

No sanitizer suppression, test removal, timeout relaxation, or unrelated dirty files are included.

## Scope note

The change does not attempt to redesign scheduler cancellation for every pre-existing accepted-job failure path; those remain outside this focused memory-safety fix.
