### PR TITLE
fix(http): bound pipeline dispatch and isolate request bodies

### DIFF
--- a/.github/workflows/bsd-kqueue-benchmarks.yml
+++ b/.github/workflows/bsd-kqueue-benchmarks.yml
@@ -41,7 +41,7 @@ jobs:
           PERF_STACK_FLAGS: -O3 -march=native -mtune=native -pipe -flto -fomit-frame-pointer -funroll-loops -fstrict-aliasing -ffunction-sections -fdata-sections -fvisibility=hidden -DNDEBUG
           PKG_CONFIG_PATH: /opt/homebrew/opt/curl/lib/pkgconfig
         run: |
-          make test_seq test_http_chunked test_mux test_test_client
+          make test_seq test_http_chunked test_mux test_test_client test_http_pipeline test_http_fairness
           make -pn | grep -E '^IO_SRC[[:space:]]*=[[:space:]]*src/sys/io/kqueue\.c$'
 
   benchmark:

--- a/Makefile
+++ b/Makefile
@@ -423,6 +423,8 @@ TEST_TARGETS = test_sstring \
                test_redis \
                test_scheduler \
                test_async_defer \
+               test_http_fairness \
+               test_http_pipeline \
                test_test_client \
                test_multiport \
                test_grpc \
@@ -810,6 +812,17 @@ cli:
 test_scheduler: $(LIB_NAME) tests/test_scheduler.c
 	$(CC) $(CFLAGS) -o test_scheduler tests/test_scheduler.c $(LIB_NAME) $(LIBS)
 	./test_scheduler
+
+test_http_pipeline: $(LIB_NAME) tests/test_http_pipeline.c
+	$(CC) $(CFLAGS) -o $@ tests/test_http_pipeline.c $(LIB_NAME) $(LIBS)
+	./$@
+
+test_http_fairness: $(LIB_NAME) tests/test_http_fairness.c
+	$(CC) $(CFLAGS) -o $@ tests/test_http_fairness.c $(LIB_NAME) $(LIBS)
+	./$@
+	CWIST_TEST_HALF_CLOSE=1 ./$@
+	CWIST_TEST_HALF_CLOSE=1 CWIST_TEST_TRUNCATED=1 ./$@
+	CWIST_TEST_DESTROY_PENDING=1 ./$@
 
 test_async_defer: $(LIB_NAME) tests/test_async_defer.c
 	$(CC) $(CFLAGS) -o test_async_defer tests/test_async_defer.c $(LIB_NAME) $(LIBS)

--- a/docs/http-reactor-fairness.md
+++ b/docs/http-reactor-fairness.md
@@ -1,0 +1,81 @@
+# HTTP/1.1 pipeline fairness and framing
+
+Related: [issue #25](https://github.com/Religiya-Serdtsa/CWIST/issues/25).
+
+## Scope
+
+The event-driven HTTP/1.1 handler serves at most **16 complete requests per
+invocation**. Buffered requests are continued through the reactor's FIFO post
+queue, not by recursively calling the handler or waiting for another read event.
+This bounds request dispatch count, not elapsed time: a blocking handler, large
+body, or synchronous file-stream operation can still occupy a reactor.
+
+The nonblocking parser's preliminary pass receives only the header block. The
+validated Content-Length/chunked assembler supplies the body afterward. This
+avoids copying subsequent pipeline messages into a body-less request and doing
+that unnecessary copy again for each request in a long pipeline.
+
+Half-close is preserved across continuations. Complete buffered requests are
+answered after the peer shuts down its write side; an incomplete trailing
+request is closed rather than rearmed forever. Pool destruction also prohibits
+new continuations from deferred completions in the final reactor drain.
+
+## Behavioral regression tests
+
+```sh
+make WERROR=1 test_http_pipeline test_http_fairness test_async_defer test_http_chunked
+```
+
+`test_http_pipeline` checks no-body GET, Content-Length: 0, a positive length,
+and chunked framing, with another request in the same stash.
+
+`test_http_fairness` gates the first pipeline handler, makes a second connection
+ready on the same reactor, then releases the gate. It checks:
+
+- the probe is served before all 256 bulk requests finish;
+- each application-handler invocation serves no more than 16 bulk requests;
+- all 256 response frames and bodies arrive in order without more client input;
+- complete and truncated-header half-close variants still drain valid requests;
+- a real deferred completion in pool destruction sends its response and closes
+  without queuing an orphan continuation, even while the global run flag is true.
+
+The assertions use service order, framing, and lifecycle rather than latency
+thresholds. Watchdog/poll timeouts only prevent a broken test from hanging.
+The Makefile runs these variants in the full suite, and the macOS focused CI
+job explicitly runs both new test targets.
+
+The dev baseline served the probe only after **256/256** requests and exposed
+later pipeline bytes as a GET body. The initial fairness implementation exposed
+two additional lifecycle regressions (half-close truncation and a post created
+inside the final destruction drain); both have dedicated regressions.
+
+## Performance claim boundary
+
+These tests establish removal of a specific head-of-line blocking mechanism.
+They do **not** establish resolution of the original issue's 645.72 ms P99.999.
+
+A separate closed-loop comparison of the repository's `GET /` benchmark app used
+Linux x86_64, GCC 13.3, wrk 4.1.0, one process/reactor, two client threads,
+concurrency 64/256/512, 2 s warmup, 10 s samples, and three rounds per variant.
+All 18 valid runs had zero transport/status errors. Throughput was similar;
+extreme percentile latency did not consistently improve. The experiment used
+the fairness/framing candidate before its final teardown-only guard and is
+not a final-release performance acceptance gate.
+
+Do not close #25 based on these results alone. Its source benchmark uses a
+different load generator; reproduce the original command, revision, worker
+settings, resource limits, and host conditions before making a general tail
+latency claim. P99.999 also needs enough observations and repeated runs.
+
+For comparable local runs, raise the **soft** descriptor limit before starting
+both client and server (within the existing hard limit), e.g. `ulimit -n 65536`.
+A 1024 soft limit made the initial diagnostic run hit CWIST's inflight admission
+limit and return 503s; those samples were discarded, not counted as latency wins.
+
+## Internal API compatibility
+
+Consumers allocating `cwist_http_async_conn_t` must rebuild for its appended
+`peer_eof` field. `cwist_http_async_conn_fill()` now returns zero for orderly EOF
+and records it in that field; callers drain complete buffered requests and then
+close. Buffered `cwist_http_async_rearm()` schedules work instead of executing it
+inline. Its existing failure contract still consumes/closes the connection.

--- a/include/cwist/net/http/http.h
+++ b/include/cwist/net/http/http.h
@@ -367,7 +367,7 @@ typedef enum {
     CWIST_ASYNC_CLOSE = 0,  /* Close fd and release the connection. */
     CWIST_ASYNC_REARM,      /* Keep the connection; wait for more reads. */
     CWIST_ASYNC_DETACH,     /* Handler took ownership of fd (h2c, upgrades). */
-    CWIST_ASYNC_DEFER       /* Response deferred (cwist_async); leave fd and conn untouched. */
+    CWIST_ASYNC_DEFER       /* Completion/continuation owns fd and conn; leave untouched. */
 } cwist_async_action_t;
 
 typedef cwist_async_action_t (*cwist_async_handler_t)(int fd, struct cwist_http_async_conn *conn);
@@ -384,11 +384,13 @@ typedef struct cwist_http_async_conn {
     uint32_t worker_id;                   /* Assigned worker thread index for load tracking. */
     cwist_reactor_t *reactor;             /* Owning reactor (deferred-response completion target). */
     cwist_async_handler_t handler;        /* Connection handler, reused for re-arm after a defer. */
+    bool peer_eof;                       /* Read side closed; drain complete buffered requests. */
 } cwist_http_async_conn_t;
 
 /* Re-arm a connection after a deferred response completed on the reactor
  * thread (keep-alive), reusing the same one-shot event slot model as
- * http_async_event_cb.  On failure the fd is closed and conn released.
+ * http_async_event_cb. Buffered bytes resume through a posted continuation,
+ * not recursively inline. On failure the fd is closed and conn released.
  * cwist_http_async_close closes the fd and releases the connection shell. */
 bool cwist_http_async_rearm(int client_fd, cwist_reactor_t *reactor, cwist_http_async_conn_t *conn);
 void cwist_http_async_close(int client_fd, cwist_http_async_conn_t *conn);
@@ -421,6 +423,8 @@ typedef enum {
 } cwist_recv_status_t;
 
 bool cwist_http_pool_submit_async(int client_fd, cwist_async_handler_t handler, void *ctx);
+/* Returns 0 on data/EAGAIN/EOF, -1 on fatal error. EOF sets peer_eof;
+ * drain complete buffered requests, then close instead of waiting for input. */
 int cwist_http_async_conn_fill(cwist_http_async_conn_t *conn);
 cwist_recv_status_t cwist_http_receive_request_nb(cwist_http_async_conn_t *conn, cwist_http_request **out, cwist_http_parse_error_t *err_out);
 

--- a/src/net/http/http.c
+++ b/src/net/http/http.c
@@ -185,6 +185,7 @@ static http_thread_worker_t *g_workers = NULL;
 static _Atomic uint32_t *g_worker_loads = NULL;
 
 static _Atomic long g_http_inflight = 0;
+static _Atomic bool g_http_pool_stopping = false;
 #define CWIST_HTTP_INFLIGHT_PER_THREAD 32
 #define CWIST_HTTP_INFLIGHT_FD_RESERVE 4096
 
@@ -323,6 +324,7 @@ static bool http_spawn_worker(void) {
 }
 
 int cwist_http_pool_init(void) {
+    atomic_store(&g_http_pool_stopping, false);
     const char *c1m = getenv("CWIST_C1M_MODE");
     bool use_c1m = true;
     if (c1m) {
@@ -422,6 +424,8 @@ bool cwist_http_pool_rearm_current(int client_fd, void (*handler)(int, void *), 
 }
 
 void cwist_http_pool_destroy(void) {
+    /* Queued continuations must release, not repost into a dying reactor. */
+    atomic_store(&g_http_pool_stopping, true);
     atomic_store_explicit(&g_dyn_pool.running, false, memory_order_release);
     pthread_mutex_lock(&g_dyn_pool.lock);
     pthread_cond_broadcast(&g_dyn_pool.cond);
@@ -568,8 +572,34 @@ static void http_async_event_cb(int fd, void *ctx) {
     }
 }
 
+typedef struct {
+    cwist_reactor_post_t post;
+    http_async_ctx_t next;
+} http_async_continuation_t;
+
+static void http_async_continue(void *ctx) {
+    http_async_continuation_t *continuation = ctx;
+    http_async_ctx_t next = continuation->next;
+    cwist_free(continuation);
+    if (!atomic_load(&g_cwist_running) || atomic_load(&g_http_pool_stopping)) {
+        cwist_http_async_close(next.client_fd, next.conn);
+        return;
+    }
+    http_async_event_cb(next.client_fd, &next);
+}
+
 bool cwist_http_async_rearm(int client_fd, cwist_reactor_t *reactor, cwist_http_async_conn_t *conn) {
     if (client_fd < 0 || !reactor || !conn) return false;
+    /* A deferred response may finish in reactor_destroy's final drain. Never
+     * enqueue new work into that final snapshot or the connection is orphaned. */
+    if (atomic_load(&g_http_pool_stopping)) {
+        cwist_http_async_close(client_fd, conn);
+        return false;
+    }
+    if (conn->peer_eof && conn->len == 0) {
+        cwist_http_async_close(client_fd, conn);
+        return false;
+    }
     conn->last_active_sec = cwist_fast_monotonic_sec();
     http_async_ctx_t next = {
         .client_fd = client_fd,
@@ -580,8 +610,23 @@ bool cwist_http_async_rearm(int client_fd, cwist_reactor_t *reactor, cwist_http_
     };
     if (conn->len > 0) {
         /* Pipelined bytes already sit in the stash: waiting for POLLIN would
-         * hang, so dispatch the pending data as if a read event had fired. */
-        http_async_event_cb(client_fd, &next);
+         * hang. Post instead of recursing inline, so ready connections can
+         * run between bounded HTTP request batches. */
+        http_async_continuation_t *continuation = cwist_alloc(sizeof(*continuation));
+        if (!continuation) {
+            cwist_http_async_close(client_fd, conn);
+            return false;
+        }
+        continuation->next = next;
+        continuation->post = (cwist_reactor_post_t) {
+            .cb = http_async_continue,
+            .ctx = continuation,
+        };
+        if (!cwist_reactor_post(reactor, &continuation->post)) {
+            cwist_free(continuation);
+            cwist_http_async_close(client_fd, conn);
+            return false;
+        }
         return true;
     }
     /* Same stash shrink as the REARM path in http_async_event_cb. */
@@ -2854,9 +2899,10 @@ static bool http_async_stash_grow(cwist_http_async_conn_t *conn, size_t need) {
  * if bytes remain after a short recv the one-shot re-arm fires again
  * immediately.  This skips the guaranteed-EAGAIN second recv that otherwise
  * costs one wasted syscall per request on non-pipelined keep-alive traffic.
- * @return 0 on success (EAGAIN or data), -1 on orderly close or fatal error.
+ * @return 0 on data, EAGAIN, or EOF (recorded in peer_eof); -1 on fatal error.
  */
 int cwist_http_async_conn_fill(cwist_http_async_conn_t *conn) {
+    if (conn->peer_eof) return 0;
     for (;;) {
         if (conn->len + 1 >= conn->cap && !http_async_stash_grow(conn, conn->len + 4096)) {
             return -1;
@@ -2870,7 +2916,11 @@ int cwist_http_async_conn_fill(cwist_http_async_conn_t *conn) {
             if ((size_t)n < avail) return 0; /* short read: drained for now */
             continue;
         }
-        if (n == 0) return -1;
+        if (n == 0) {
+            /* A half-close does not discard already buffered requests. */
+            conn->peer_eof = true;
+            return 0;
+        }
         if (errno == EINTR) continue;
         if (errno == EAGAIN || errno == EWOULDBLOCK) return 0;
         return -1;
@@ -2939,10 +2989,12 @@ cwist_recv_status_t cwist_http_receive_request_nb(cwist_http_async_conn_t *conn,
         return CWIST_RECV_NEED_MORE;
     }
 
-    cwist_http_request *req = cwist_http_parse_request_with_header_end(conn->rbuf, conn->len, header_end, err_out);
+    /* Framing below assembles this request's body. Passing the whole stash
+     * here copies later pipelined messages into body-less requests too. */
+    size_t header_len = (size_t)(header_end + 4 - conn->rbuf);
+    cwist_http_request *req = cwist_http_parse_request_with_header_end(conn->rbuf, header_len, header_end, err_out);
     if (!req) return CWIST_RECV_FATAL;
 
-    size_t header_len = (size_t)(header_end + 4 - conn->rbuf);
     size_t body_received = conn->len - header_len;
     size_t consumed = header_len;
 

--- a/src/sys/app/app.c
+++ b/src/sys/app/app.c
@@ -2325,9 +2325,11 @@ static app_serve_result_t app_serve_parsed_request(cwist_app *app, int client_fd
 
 /**
  * @brief Event-driven HTTP/1.1 handler for the C1M reactor path.
- * Drains the socket without blocking, serves every complete request in the
- * stash, then tells the pool whether to rearm, close, or detach the fd.
+ * Drains the socket without blocking and serves a bounded request batch.
+ * Remaining buffered work is posted so other ready connections can run.
  */
+#define CWIST_HTTP_REQUESTS_PER_TURN 16
+
 cwist_async_action_t cwist_app_http_handler_async(int client_fd, cwist_http_async_conn_t *conn) {
     cwist_app *app = (cwist_app *)conn->user_ctx;
     static _Atomic long dbg_fill_fail, dbg_fatal, dbg_serve_close;
@@ -2380,11 +2382,15 @@ cwist_async_action_t cwist_app_http_handler_async(int client_fd, cwist_http_asyn
     /* Jeungseung Gaebang Scaling for priority weighting. */
     uint32_t priority_weight = ((mixed_seed * 16777619U) >> 8) % 100;
 
-    for (;;) {
+    /* One pipeline must not monopolize this reactor's other connections. */
+    for (unsigned int handled = 0; handled < CWIST_HTTP_REQUESTS_PER_TURN; ++handled) {
         cwist_http_request *req = NULL;
         cwist_http_parse_error_t perr = CWIST_HTTP_PARSE_OK;
         cwist_recv_status_t st = cwist_http_receive_request_nb(conn, &req, &perr);
-        if (st == CWIST_RECV_NEED_MORE) return CWIST_ASYNC_REARM;
+        if (st == CWIST_RECV_NEED_MORE) {
+            /* EOF with no complete frame must close, not wait or repost. */
+            return conn->peer_eof ? CWIST_ASYNC_CLOSE : CWIST_ASYNC_REARM;
+        }
         if (st == CWIST_RECV_FATAL) {
             app_maybe_send_parse_error(client_fd, perr);
             if (dbg) {
@@ -2411,6 +2417,13 @@ cwist_async_action_t cwist_app_http_handler_async(int client_fd, cwist_http_asyn
             return CWIST_ASYNC_CLOSE;
         }
     }
+    if (conn->len > 0) {
+        /* Buffered work cannot wait for another read event. The continuation
+         * owns fd/conn on success; rearm closes both on failure. */
+        cwist_http_async_rearm(client_fd, conn->reactor, conn);
+        return CWIST_ASYNC_DEFER;
+    }
+    return conn->peer_eof ? CWIST_ASYNC_CLOSE : CWIST_ASYNC_REARM;
 }
 
 void cwist_app_http_handler(int client_fd, void *ctx) {

--- a/tests/test_http_fairness.c
+++ b/tests/test_http_fairness.c
@@ -1,0 +1,272 @@
+/**
+ * Regression for #25: a ready pipeline must not monopolize one reactor.
+ * The first handler is gated while a second connection becomes ready. Check
+ * service order, not a timing threshold, and drain the entire pipeline without
+ * sending more bytes (buffered continuations must not wait for another read).
+ */
+#include <cwist/sys/app/app.h>
+#include <cwist/sys/app/shutdown.h>
+#include <cwist/sys/io/reactor.h>
+#include <cwist/net/http/async.h>
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <pthread.h>
+#include <signal.h>
+#include <stdatomic.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <time.h>
+#include <unistd.h>
+
+#define REQUESTS 256
+#define RESPONSE_CAP (256 * 1024)
+
+static pthread_mutex_t gate_lock = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t gate_cv = PTHREAD_COND_INITIALIZER;
+static int entered, released;
+static int bulk_count, probe_at;
+static long delay_us;
+static cwist_reactor_t *reactor;
+static int max_batch;
+static bool destroy_pending;
+static cwist_async *pending;
+
+extern cwist_async_action_t cwist_app_http_handler_async(int, cwist_http_async_conn_t *);
+
+static cwist_async_action_t dispatch(int fd, cwist_http_async_conn_t *conn) {
+    if (!reactor) reactor = conn->reactor;
+    int before = bulk_count;
+    cwist_async_action_t action = cwist_app_http_handler_async(fd, conn);
+    if (destroy_pending) {
+        assert(action == CWIST_ASYNC_DEFER);
+        pthread_mutex_lock(&gate_lock);
+        entered = 1;
+        pthread_cond_signal(&gate_cv);
+        while (!released) pthread_cond_wait(&gate_cv, &gate_lock);
+        pthread_mutex_unlock(&gate_lock);
+    }
+    if (bulk_count - before > max_batch) max_batch = bulk_count - before;
+    return action;
+}
+
+static void wake_for_shutdown(void *unused) {
+    (void)unused;
+}
+
+static void bulk_handler(cwist_http_request *req, cwist_http_response *res) {
+    (void)req;
+    ++bulk_count;
+    if (bulk_count == 1) {
+        pthread_mutex_lock(&gate_lock);
+        entered = 1;
+        pthread_cond_signal(&gate_cv);
+        while (!released) pthread_cond_wait(&gate_cv, &gate_lock);
+        pthread_mutex_unlock(&gate_lock);
+    }
+    if (delay_us > 0) {
+        struct timespec delay = {.tv_sec = delay_us / 1000000,
+                                .tv_nsec = (delay_us % 1000000) * 1000};
+        nanosleep(&delay, NULL);
+    }
+    char body[32];
+    snprintf(body, sizeof(body), "item-%03d", bulk_count);
+    cwist_sstring_assign(res->body, body);
+}
+
+static void defer_handler(cwist_http_request *req, cwist_http_response *res) {
+    pending = cwist_async_defer(req, res);
+    assert(pending);
+    cwist_async_retain(pending);
+}
+
+static void probe_handler(cwist_http_request *req, cwist_http_response *res) {
+    (void)req;
+    probe_at = bulk_count;
+    cwist_sstring_assign(res->body, "probe");
+}
+
+static void write_all(int fd, const char *data, size_t len) {
+    while (len) {
+        ssize_t n = write(fd, data, len);
+        if (n < 0 && errno == EINTR) continue;
+        assert(n > 0);
+        data += n;
+        len -= (size_t)n;
+    }
+}
+
+/* Verify exact framing/body/order, not just a matching substring count. */
+static void check_responses(char *data, size_t len) {
+    size_t off = 0;
+    for (int i = 1; i <= REQUESTS; ++i) {
+        assert(off < len);
+        assert(strncmp(data + off, "HTTP/1.1 200 ", 13) == 0);
+        char *end = strstr(data + off, "\r\n\r\n");
+        assert(end);
+        char *cl = strstr(data + off, "Content-Length: ");
+        assert(cl && cl < end);
+        size_t body_len = (size_t)strtoul(cl + 16, NULL, 10);
+        off = (size_t)(end - data) + 4;
+        char body[32];
+        snprintf(body, sizeof(body), "item-%03d", i);
+        assert(body_len == strlen(body) && body_len <= len - off);
+        assert(memcmp(data + off, body, body_len) == 0);
+        off += body_len;
+    }
+    assert(off == len);
+}
+
+/* Queue a real deferred completion for the destructor's final post drain.
+ * Keep the global run flag true: pool teardown alone must prohibit rearming. */
+static void check_destroy_pending(cwist_app *app) {
+    int fds[2];
+    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, fds) == 0);
+    const char requests[] = "GET /defer HTTP/1.1\r\nHost: x\r\n\r\n"
+                            "GET /bulk HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n";
+    write_all(fds[1], requests, sizeof(requests) - 1);
+    assert(cwist_http_pool_submit_async(fds[0], dispatch, app));
+    pthread_mutex_lock(&gate_lock);
+    while (!entered) pthread_cond_wait(&gate_cv, &gate_lock);
+    assert(cwist_async_respond(pending, CWIST_HTTP_OK, "text/plain", "done", 4));
+    cwist_async_release(pending);
+    /* Stop while the owner is gated, before it can drain the posted response. */
+    cwist_reactor_stop(reactor);
+    released = 1;
+    pthread_cond_signal(&gate_cv);
+    pthread_mutex_unlock(&gate_lock);
+    cwist_http_pool_destroy();
+    assert(atomic_load(&g_cwist_running));
+
+    char response[4096] = {0};
+    size_t used = 0;
+    for (;;) {
+        struct pollfd pfd = {.fd = fds[1], .events = POLLIN};
+        assert(poll(&pfd, 1, 1000) == 1); /* Must receive EOF, not an orphan fd. */
+        assert(used < sizeof(response) - 1);
+        ssize_t n = read(fds[1], response + used, sizeof(response) - 1 - used);
+        assert(n >= 0);
+        if (n == 0) break;
+        used += (size_t)n;
+    }
+    assert(strstr(response, "\r\n\r\ndone"));
+    assert(bulk_count == 0);
+    close(fds[1]);
+    cwist_app_destroy(app);
+    puts("Deferred completion during pool destruction test passed");
+}
+
+int main(void) {
+    /* A hard watchdog catches lost continuations; no latency threshold decides
+     * whether fairness passes. Optional delay is for the focused benchmark. */
+    alarm(30);
+    signal(SIGPIPE, SIG_IGN);
+    setenv("CWIST_WORKERS", "1", 1);
+    setenv("CWIST_WORKER_THREADS", "1", 1);
+    setenv("CWIST_C1M_MODE", "1", 1);
+    const char *delay = getenv("CWIST_TEST_HANDLER_DELAY_US");
+    delay_us = delay ? strtol(delay, NULL, 10) : 0;
+    bool half_close = getenv("CWIST_TEST_HALF_CLOSE") != NULL;
+    bool truncated = getenv("CWIST_TEST_TRUNCATED") != NULL;
+    destroy_pending = getenv("CWIST_TEST_DESTROY_PENDING") != NULL;
+    assert(delay_us >= 0 && delay_us <= 10000);
+    atomic_store(&g_cwist_running, true);
+
+    cwist_app *app = cwist_app_create();
+    assert(app);
+    cwist_app_get(app, "/bulk", bulk_handler);
+    cwist_app_get(app, "/probe", probe_handler);
+    cwist_app_get(app, "/defer", defer_handler);
+    assert(cwist_http_pool_init() == 0);
+    if (destroy_pending) {
+        check_destroy_pending(app);
+        return 0;
+    }
+
+    int bulk[2], probe[2];
+    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, bulk) == 0);
+    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, probe) == 0);
+    /* Fit all requests in the initial recv stash so the test cannot depend on
+     * more input arriving to resume buffered work. */
+    char pipeline[16384];
+    size_t size = 0;
+    for (int i = 1; i <= REQUESTS; ++i) {
+        int n = snprintf(pipeline + size, sizeof(pipeline) - size,
+                         "GET /bulk HTTP/1.1\r\nHost: x\r\n%s\r\n",
+                         i == REQUESTS && !half_close ? "Connection: close\r\n" : "");
+        assert(n > 0 && (size_t)n < sizeof(pipeline) - size);
+        size += (size_t)n;
+    }
+    write_all(bulk[1], pipeline, size);
+    if (half_close) {
+        if (truncated) {
+            const char partial[] = "GET /bulk HTTP/1.1\r\nHost: ";
+            write_all(bulk[1], partial, sizeof(partial) - 1);
+        }
+        assert(shutdown(bulk[1], SHUT_WR) == 0);
+    }
+    assert(cwist_http_pool_submit_async(bulk[0], dispatch, app));
+    pthread_mutex_lock(&gate_lock);
+    while (!entered) pthread_cond_wait(&gate_cv, &gate_lock);
+    const char request[] = "GET /probe HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n";
+    write_all(probe[1], request, sizeof(request) - 1);
+    assert(cwist_http_pool_submit_async(probe[0], dispatch, app));
+    struct timespec start, finish;
+    clock_gettime(CLOCK_MONOTONIC, &start);
+    released = 1;
+    pthread_cond_signal(&gate_cv);
+    pthread_mutex_unlock(&gate_lock);
+
+    struct pollfd fds[2] = {{.fd = bulk[1], .events = POLLIN},
+                           {.fd = probe[1], .events = POLLIN}};
+    char *responses[2] = {calloc(1, RESPONSE_CAP), calloc(1, RESPONSE_CAP)};
+    assert(responses[0] && responses[1]);
+    size_t used[2] = {0, 0};
+    int live = 2;
+    double probe_ms = -1;
+    while (live) {
+        int n = poll(fds, 2, 10000);
+        if (n < 0 && errno == EINTR) continue;
+        assert(n > 0);
+        for (int i = 0; i < 2; ++i) {
+            if (fds[i].fd < 0 || !fds[i].revents) continue;
+            assert(used[i] < RESPONSE_CAP - 1);
+            ssize_t got = read(fds[i].fd, responses[i] + used[i], RESPONSE_CAP - 1 - used[i]);
+            if (got < 0 && errno == EINTR) continue;
+            assert(got >= 0);
+            if (got == 0) {
+                close(fds[i].fd);
+                fds[i].fd = -1;
+                --live;
+                if (i == 1) {
+                    clock_gettime(CLOCK_MONOTONIC, &finish);
+                    probe_ms = (finish.tv_sec - start.tv_sec) * 1000.0 +
+                               (finish.tv_nsec - start.tv_nsec) / 1e6;
+                }
+            } else {
+                used[i] += (size_t)got;
+            }
+        }
+    }
+    atomic_store(&g_cwist_running, false);
+    /* Wake kqueue too: its idle wait does not have the Linux timeout. */
+    cwist_reactor_post_t wake = { .cb = wake_for_shutdown };
+    assert(cwist_reactor_post(reactor, &wake));
+    cwist_http_pool_destroy();
+    check_responses(responses[0], used[0]);
+    assert(strstr(responses[1], "\r\n\r\nprobe"));
+    assert(bulk_count == REQUESTS);
+    printf("pipeline=%d probe_after=%d probe_ms=%.3f delay_us=%ld\n",
+           bulk_count, probe_at, probe_ms, delay_us);
+    fflush(stdout);
+    free(responses[0]);
+    free(responses[1]);
+    cwist_app_destroy(app);
+    assert(probe_at > 0 && probe_at < REQUESTS);
+    assert(max_batch <= 16);
+    puts("HTTP reactor fairness test passed");
+    return 0;
+}

--- a/tests/test_http_pipeline.c
+++ b/tests/test_http_pipeline.c
@@ -1,0 +1,41 @@
+/** Request bodies must not include subsequent pipelined messages (#25). */
+#include <cwist/net/http/http.h>
+#include <cwist/core/mem/alloc.h>
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+static void check_pipeline(const char *first, const char *body) {
+    const char next[] = "GET /next HTTP/1.1\r\nHost: x\r\n\r\n";
+    size_t first_len = strlen(first);
+    cwist_http_async_conn_t conn = { .fd = -1 };
+    conn.cap = first_len + sizeof(next);
+    conn.rbuf = cwist_alloc(conn.cap);
+    assert(conn.rbuf);
+    memcpy(conn.rbuf, first, first_len);
+    memcpy(conn.rbuf + first_len, next, sizeof(next));
+    conn.len = conn.cap - 1;
+    cwist_http_request *req = NULL;
+    cwist_http_parse_error_t err;
+    assert(cwist_http_receive_request_nb(&conn, &req, &err) == CWIST_RECV_OK);
+    assert(req && err == CWIST_HTTP_PARSE_OK);
+    assert(req->body && req->body->size == strlen(body));
+    if (*body) assert(memcmp(req->body->data, body, strlen(body)) == 0);
+    assert(conn.len == sizeof(next) - 1);
+    assert(memcmp(conn.rbuf, next, sizeof(next)) == 0);
+    cwist_http_request_destroy(req);
+    assert(cwist_http_receive_request_nb(&conn, &req, &err) == CWIST_RECV_OK);
+    assert(req && strcmp(req->path->data, "/next") == 0);
+    assert(req->body->size == 0 && conn.len == 0);
+    cwist_http_request_destroy(req);
+    cwist_free(conn.rbuf);
+}
+
+int main(void) {
+    check_pipeline("GET /first HTTP/1.1\r\nHost: x\r\n\r\n", "");
+    check_pipeline("POST /first HTTP/1.1\r\nHost: x\r\nContent-Length: 0\r\n\r\n", "");
+    check_pipeline("POST /first HTTP/1.1\r\nHost: x\r\nContent-Length: 4\r\n\r\nbody", "body");
+    check_pipeline("POST /first HTTP/1.1\r\nHost: x\r\nTransfer-Encoding: chunked\r\n\r\n4\r\nbody\r\n0\r\n\r\n", "body");
+    puts("HTTP pipeline body isolation tests passed");
+    return 0;
+}


### PR DESCRIPTION
## Scope

Related to #25. This fixes reproduced pipeline defects in `dev`; it does **not** claim to resolve the original non-pipelined P99.999 results or automatically close the issue.

## Changes

- Limit HTTP/1.1 dispatch to 16 requests per callback and queue buffered continuations instead of recursing or waiting for another socket event.
- Parse only the current header block, preventing following requests from leaking into body-less request bodies.
- Preserve buffered requests across peer half-close; close truncated input at EOF.
- Reject continuation rearming during pool destruction to avoid orphaned sockets/posts.
- Add deterministic framing/fairness/half-close/destructor regressions and run them in the macOS kqueue gate.

## Evidence

- Before: competing request ran after all 256 pipeline requests; no-body parsing included subsequent messages.
- After: probe ran after 32 requests; each callback served at most 16; all 256 responses retained exact framing/order.
- Half-close and destructor edge cases were reproduced RED before their corrections.
- Optimized WERROR focused tests and independent correctness/security review: PASS.
- Benchmark-rendering tests on latest dev integration: 8 PASS.
- 18 diagnostic wrk runs had zero errors but did NOT establish a general P99.999 improvement. See docs/http-reactor-fairness.md for limitations.
- Clean ASan/UBSan full suite is running; GitHub platform/interop checks are pending.

Base: dev at 56c6893244f3610f7ea0e87dcf91a6bc5e8ec1a3. No unrelated case-colliding documentation changes included.
