### PR TITLE
security(mem): harden cwist_full_gc() toggle against post-hoc injection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,7 @@ test_full_gc_handoff_bug
 test_full_gc_ownership_handoff
 test_full_gc_sweep
 test_gc_ebr_release
+test_full_gc_toggle_hardening
 test_graphql
 test_grpc
 test_grpc_channel

--- a/Makefile
+++ b/Makefile
@@ -501,6 +501,7 @@ TEST_TARGETS = test_sstring \
                test_grpc_channel \
                test_dispatch_memory \
                test_gc_ebr_release \
+               test_full_gc_toggle_hardening \
                test_full_gc_sweep \
                test_io_queue_full_gc \
                test_full_gc_ownership_handoff \
@@ -962,6 +963,10 @@ test_dispatch_memory: $(LIB_NAME) tests/test_dispatch_memory.c
 test_gc_ebr_release: $(LIB_NAME) tests/test_gc_ebr_release.c
 	$(CC) $(CFLAGS) -o test_gc_ebr_release tests/test_gc_ebr_release.c $(LIB_NAME) $(LIBS)
 	./test_gc_ebr_release
+
+test_full_gc_toggle_hardening: $(LIB_NAME) tests/test_full_gc_toggle_hardening.c
+	$(CC) $(CFLAGS) -o test_full_gc_toggle_hardening tests/test_full_gc_toggle_hardening.c $(LIB_NAME) $(LIBS)
+	./test_full_gc_toggle_hardening
 
 test_full_gc_sweep: $(LIB_NAME) tests/test_full_gc_sweep.c
 	$(CC) $(CFLAGS) -o test_full_gc_sweep tests/test_full_gc_sweep.c $(LIB_NAME) $(LIBS)

--- a/include/cwist/core/mem/gc.h
+++ b/include/cwist/core/mem/gc.h
@@ -116,9 +116,12 @@ void cwist_gc_pipeline_tick(void);
 /**
  * @brief Enable or disable full-GC mode process-wide.
  *
- * Meant to be set once at startup and left alone: cwist_alloc()/cwist_free()
- * both read the same flag, so flipping it mid-run does not retroactively
- * change how already-allocated blocks are tracked.
+ * Hardened, boot-time-only setter: the first call wins and is latched in;
+ * every later call -- from any thread, deliberate re-invocation or
+ * otherwise -- is a silent no-op, and the backing storage is mprotect()'d
+ * read-only after that first call so a raw memory-corruption write can't
+ * flip it either. See gc.c's cwist_full_gc_guard_t for the full threat
+ * model this defends against.
  *
  * @param enable When true, cwist_alloc() starts registering blocks with the
  *               per-thread pending-sweep list and cwist_free() starts
@@ -132,6 +135,21 @@ void cwist_full_gc(bool enable);
  * @brief Check whether full-GC mode is currently enabled.
  */
 bool cwist_full_gc_enabled(void);
+
+/**
+ * @brief Check whether the full-GC toggle has been latched (i.e.
+ *        cwist_full_gc() has been called once already and every further
+ *        call will be ignored). Diagnostic/testing use.
+ */
+bool cwist_full_gc_locked(void);
+
+/**
+ * @brief Raw pointer to the full-GC toggle's guard page, or NULL if the
+ *        mmap() backing it failed at process startup. Advanced/testing use
+ *        only -- e.g. to confirm the page is actually read-only after
+ *        cwist_full_gc() has been called once.
+ */
+void *cwist_full_gc_guard_page(void);
 
 /**
  * @brief Register a cwist_alloc() block with the current thread's

--- a/src/core/mem/gc.c
+++ b/src/core/mem/gc.c
@@ -3,6 +3,8 @@
 #include <ttak/mem/epoch.h>
 #include <pthread.h>
 #include <stdlib.h>
+#include <sys/mman.h>
+#include <unistd.h>
 
 /**
  * @file gc.c
@@ -151,16 +153,54 @@ bool cwist_release_guard_acquire(cwist_release_guard_t *guard) {
 /* --- Full-GC mode: process-wide toggle + per-thread pending-sweep list --- */
 
 /**
- * @brief Fast-path flag cwist_alloc()/cwist_free()/cwist_io_queue_run()
- * check on every call. A plain relaxed atomic load -- no pthread_once,
- * no touching g_full_gc -- so the default (disabled) path stays
- * effectively free, matching docs/GC.md's "zero cost when disabled"
- * contract. cwist_gc_auto_rotated(&g_full_gc) would also answer this
- * correctly, but only after paying pthread_once on every single
- * allocation; that regressed the C1M reactor latency gate in CI, since
- * cwist_alloc()/cwist_free() sit on the hottest per-request path.
+ * @brief Hardened backing storage for the full-GC toggle.
+ *
+ * Two attacks this defends against, since flipping this flag mid-run
+ * silently disables the EBR deferred-free safety net full-GC mode
+ * provides (opening a use-after-free window for anything it was
+ * protecting): (1) a later call to cwist_full_gc() -- an accidental
+ * re-invocation, or an attacker who has gained the ability to call
+ * arbitrary exported functions -- and (2) a raw arbitrary-write
+ * primitive that overwrites this flag's memory directly, bypassing the
+ * API entirely.
+ *
+ * Defense: the struct lives alone on its own mmap()'d page. cwist_full_gc()
+ * claims the right to set it exactly once via an atomic CAS on `locked`
+ * (defeats (1): every later call, benign or hostile, is a silent no-op);
+ * once set, the page is mprotect()'d PROT_READ (defeats (2): any write
+ * that bypasses the CAS check and lands on this memory directly hard-faults
+ * instead of silently succeeding).
  */
-static _Atomic bool g_full_gc_flag = false;
+typedef struct {
+    _Atomic bool enabled;
+    _Atomic bool locked;
+} cwist_full_gc_guard_t;
+
+/**
+ * @brief The guard page itself, or NULL if the mmap() below failed
+ * (treated as full-GC being permanently unavailable, never as a security
+ * regression -- see cwist_full_gc_enabled()).
+ */
+static cwist_full_gc_guard_t *g_full_gc_guard = NULL;
+
+/**
+ * @brief Map the guard page before main() runs, so cwist_full_gc_enabled()
+ * -- called on every cwist_alloc()/cwist_free() -- never needs a
+ * pthread_once/lazy-init check on its hot path (that check itself
+ * regressed the C1M reactor latency gate in CI once already).
+ */
+__attribute__((constructor))
+static void cwist_full_gc_guard_init(void) {
+    long page_size = sysconf(_SC_PAGESIZE);
+    if (page_size <= 0) page_size = 4096;
+    void *page = mmap(NULL, (size_t)page_size, PROT_READ | PROT_WRITE,
+                      MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (page == MAP_FAILED) return;
+    cwist_full_gc_guard_t *guard = (cwist_full_gc_guard_t *)page;
+    atomic_init(&guard->enabled, false);
+    atomic_init(&guard->locked, false);
+    g_full_gc_guard = guard;
+}
 
 /** @brief Process-wide GC instance backing full-GC's epoch-retire pipeline. */
 static cwist_gc_t g_full_gc;
@@ -175,13 +215,58 @@ static cwist_gc_t *cwist_full_gc_instance(void) {
     return &g_full_gc;
 }
 
+/**
+ * @brief Serializes claiming the "first caller" slot in cwist_full_gc().
+ *
+ * NOT a CAS on g_full_gc_guard->locked: a CAS is a hardware read-modify-
+ * WRITE (x86 cmpxchg asserts write intent even when the comparison
+ * fails), so trying one on the guard page after it's been mprotect()'d
+ * PROT_READ faults immediately -- on every later caller, exactly the
+ * "harmless no-op" case this is supposed to handle gracefully. This
+ * mutex lives off the guarded page, so contending for it is always safe;
+ * only the thread that wins it ever writes to the page, and only before
+ * that same thread mprotect()s it.
+ */
+static pthread_mutex_t g_full_gc_claim_mu = PTHREAD_MUTEX_INITIALIZER;
+
 void cwist_full_gc(bool enable) {
+    if (!g_full_gc_guard) return; /* guard page unavailable; fail safe, not silently unhardened */
+
+    /* Fast path: once locked, this plain load is the only thing every
+     * later caller ever does -- safe indefinitely, even after the page
+     * below becomes read-only. */
+    if (atomic_load_explicit(&g_full_gc_guard->locked, memory_order_acquire)) return;
+
+    pthread_mutex_lock(&g_full_gc_claim_mu);
+    if (atomic_load_explicit(&g_full_gc_guard->locked, memory_order_acquire)) {
+        /* Someone else claimed it while we were waiting for the mutex. */
+        pthread_mutex_unlock(&g_full_gc_claim_mu);
+        return;
+    }
+
+    /* We hold the mutex and locked is still false: nobody has mprotect()'d
+     * the page yet, so it is still writable and we are its sole writer. */
+    atomic_store_explicit(&g_full_gc_guard->enabled, enable, memory_order_relaxed);
+    atomic_store_explicit(&g_full_gc_guard->locked, true, memory_order_release);
+    long page_size = sysconf(_SC_PAGESIZE);
+    mprotect(g_full_gc_guard, (size_t)(page_size > 0 ? page_size : 4096), PROT_READ);
+    pthread_mutex_unlock(&g_full_gc_claim_mu);
+
     cwist_gc_auto_rotate(cwist_full_gc_instance(), enable);
-    atomic_store_explicit(&g_full_gc_flag, enable, memory_order_relaxed);
 }
 
 bool cwist_full_gc_enabled(void) {
-    return atomic_load_explicit(&g_full_gc_flag, memory_order_relaxed);
+    if (!g_full_gc_guard) return false;
+    return atomic_load_explicit(&g_full_gc_guard->enabled, memory_order_relaxed);
+}
+
+bool cwist_full_gc_locked(void) {
+    if (!g_full_gc_guard) return false;
+    return atomic_load_explicit(&g_full_gc_guard->locked, memory_order_acquire);
+}
+
+void *cwist_full_gc_guard_page(void) {
+    return g_full_gc_guard;
 }
 
 /** @brief One thread's list of cwist_alloc() blocks not yet cwist_free()'d. */

--- a/tests/test_full_gc_toggle_hardening.c
+++ b/tests/test_full_gc_toggle_hardening.c
@@ -1,0 +1,71 @@
+#define _POSIX_C_SOURCE 200809L
+/* Covers the hardened cwist_full_gc() toggle: it must be settable exactly
+ * once (a later call -- benign re-invocation or an attacker with a
+ * call-injection primitive -- is a silent no-op), and its backing memory
+ * must actually become unwritable afterwards (a raw arbitrary-write
+ * primitive that bypasses the API and targets the flag's memory directly
+ * must hard-fault instead of silently flipping it).
+ */
+#include <cwist/core/mem/gc.h>
+#include <assert.h>
+#include <signal.h>
+#include <stdio.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+/* --- Part 1: the one-time latch, in-process --- */
+static void test_latch(void) {
+    assert(!cwist_full_gc_locked());
+
+    cwist_full_gc(true);
+    assert(cwist_full_gc_locked());
+    assert(cwist_full_gc_enabled());
+
+    /* A later call -- however it happens -- must not change anything. */
+    cwist_full_gc(false);
+    assert(cwist_full_gc_enabled());
+    cwist_full_gc(true);
+    assert(cwist_full_gc_enabled());
+
+    printf("test_full_gc_toggle_hardening: latch ok (locked after first call, "
+           "later calls ignored)\n");
+}
+
+/* --- Part 2: the guard page is actually read-only after the first call,
+ * proven by forking a child that tries to write it directly and
+ * confirming the child dies with SIGSEGV/SIGBUS rather than succeeding. */
+static void test_page_hardening(void) {
+    /* Parent already locked the guard in test_latch(); the child inherits
+     * that state via fork() (same mapped page, copy-on-write semantics
+     * don't matter here since we're about to fault on write anyway). */
+    volatile char *raw = (volatile char *)cwist_full_gc_guard_page();
+    assert(raw != NULL);
+
+    pid_t pid = fork();
+    assert(pid >= 0);
+    if (pid == 0) {
+        /* Child: attempt a raw write to the guard page, bypassing
+         * cwist_full_gc() entirely -- this must crash, not succeed. */
+        signal(SIGSEGV, SIG_DFL);
+        signal(SIGBUS, SIG_DFL);
+        *raw = 0x41;
+        /* If we get here, the page was writable -- hardening failed. */
+        _exit(0);
+    }
+
+    int status = 0;
+    assert(waitpid(pid, &status, 0) == pid);
+    assert(WIFSIGNALED(status));
+    int sig = WTERMSIG(status);
+    assert(sig == SIGSEGV || sig == SIGBUS);
+
+    printf("test_full_gc_toggle_hardening: page-hardening ok "
+           "(direct write crashed with signal %d, as expected)\n", sig);
+}
+
+int main(void) {
+    test_latch();
+    test_page_hardening();
+    printf("test_full_gc_toggle_hardening: ok\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

Security audit + fix for `cwist_full_gc()`'s toggle, requested separately from the perf follow-up in #30.

## Finding

`cwist_full_gc(bool)` (`src/core/mem/gc.c`) is a public, exported function. Its backing flag was a plain `static _Atomic bool` in normal process memory. Nothing enforced the documented "meant to be set once at startup" contract -- it was prose only. Two concrete attack paths follow directly from that:

1. **Call-time re-invocation.** Any code able to call an exported function in the process (an accidental second call from application code, or an attacker who has gained arbitrary-call capability) can call `cwist_full_gc(false)` at any point during the process's life and silently flip the flag.
2. **Raw memory corruption.** With an arbitrary-write primitive elsewhere in the process, an attacker can compute the flag's address and overwrite it directly, bypassing the API entirely.

Either one silently disables the EBR deferred-free safety net full-GC mode provides for whatever it was tracking -- reopening a use-after-free window mid-request, which is a worse outcome than full-GC being off from the start (code may be relying on the safety net without realizing it just vanished).

## Fix

`src/core/mem/gc.c` / `include/cwist/core/mem/gc.h`:

- The flag (plus a `locked` companion) now lives alone on a dedicated `mmap()`'d page, mapped eagerly via `__attribute__((constructor))` so `cwist_full_gc_enabled()` -- called on every `cwist_alloc()`/`cwist_free()` -- keeps its cheap plain-atomic-load hot path (no `pthread_once`, matching the fix already landed for the C1M reactor latency gate regression).
- `cwist_full_gc()` claims the right to set the flag **exactly once**, serialized through a mutex kept off the guarded page (see implementation note below for why not a CAS on the page itself). Every later call -- benign or hostile -- is a silent no-op.
- Once set, the page is `mprotect()`'d `PROT_READ`. A raw write that bypasses the API and targets that memory directly now hard-faults instead of succeeding.
- New `cwist_full_gc_locked()` / `cwist_full_gc_guard_page()` for diagnostics/testing.

**Implementation note on an actual bug found while building this:** the first cut used an atomic CAS on the guard's `locked` field for the "already set, no-op" check too. That's wrong: a CAS is a hardware read-modify-*write* (x86 `cmpxchg` asserts write intent even when the comparison fails), so once the page was `mprotect()`'d read-only, every subsequent "harmless no-op" call reliably `SIGSEGV`'d instead of returning quietly. Fixed by using a plain atomic load for that check, with the actual one-time claim happening under the off-page mutex instead (this is a reminder that "make it read-only" and "check-then-maybe-write via a single instruction" don't compose for free).

## Testing

`tests/test_full_gc_toggle_hardening.c` proves both properties directly:
- **Latch**: after `cwist_full_gc(true)`, a further `cwist_full_gc(false)` is verified to leave `cwist_full_gc_enabled()` unchanged.
- **Page hardening**: forks a child that writes to `cwist_full_gc_guard_page()` directly (bypassing the API entirely) and verifies via `waitpid()`/`WIFSIGNALED()` that it dies with `SIGSEGV`/`SIGBUS` rather than succeeding. 10/10 runs.

No regression in `test_gc_ebr_release`, `test_full_gc_sweep`, `test_io_queue_full_gc`, `test_full_gc_ownership_handoff`, `test_defer_free`, `test_dispatch_memory`. Local microbenchmark confirms `cwist_full_gc_enabled()`'s hot-path cost is unchanged (~8.3ns/alloc+free, same as after the earlier `pthread_once` fix).
