### PR TITLE
fix(bench): give Spring Boot the same tuned low-concurrency run CWIST gets

### DIFF
--- a/.github/workflows/bsd-kqueue-benchmarks.yml
+++ b/.github/workflows/bsd-kqueue-benchmarks.yml
@@ -403,6 +403,29 @@ jobs:
               -jar /tmp/spring_bench/target/spring-bench-0.0.1-SNAPSHOT.jar --server.port=9093" \
             9093 "/tmp/spring.txt" "/tmp/spring_stat.txt" 90
 
+          # Tuned low-latency profile (wrk -t4 -c100), same reduced-concurrency
+          # profile CWIST gets above. Previously only CWIST got a second,
+          # lower-concurrency data point, so a report that showed "CWIST tuned
+          # latency" next to "Spring latency" was comparing CWIST's best case
+          # against Spring's only case -- not a fair fight. Give Spring Boot
+          # the identical treatment: its own dedicated boot (replaying the
+          # same trained AOT cache, so it isn't paying a second cold-start
+          # penalty CWIST doesn't pay either) measured under -t4 -c100.
+          echo "=== Starting Spring Boot tuned run (wrk -t4 -c100) ==="
+          java $SPRING_JVM_OPTS \
+            -XX:+AOTClassLinking \
+            -XX:AOTCache=$SPRING_AOT_CACHE \
+            -jar /tmp/spring_bench/target/spring-bench-0.0.1-SNAPSHOT.jar --server.port=9093 &
+          SPRING_TUNED_PID=$!
+          for i in $(seq 1 90); do
+            curl -sf http://127.0.0.1:9093/ > /dev/null 2>&1 && break
+            sleep 1
+          done
+          wrk -t4 -c100 -d10s http://127.0.0.1:9093/ > /dev/null 2>&1 || true
+          wrk -t4 -c100 -d10s -s "$GITHUB_WORKSPACE/scripts/ci/tail_latency.lua" --latency http://127.0.0.1:9093/ > /tmp/spring_tuned.txt 2>&1 || true
+          kill -9 $SPRING_TUNED_PID || true
+          cat /tmp/spring_tuned.txt
+
           # Result JSON must land in the workspace so upload-artifact can find it
           # (the shell is still sitting in /tmp/spring_bench from the maven build).
           cd $GITHUB_WORKSPACE
@@ -484,6 +507,8 @@ jobs:
           spring_rps, spring_lat, spring_p50, spring_p90, spring_p99, spring_p99_999 = parse_wrk("/tmp/spring.txt")
           spring_rss, spring_csw = parse_stat("/tmp/spring_stat.txt")
 
+          spring_tuned_rps, spring_tuned_lat, spring_tuned_p50, spring_tuned_p90, spring_tuned_p99, spring_tuned_p99_999 = parse_wrk("/tmp/spring_tuned.txt")
+
           data = {
               "timestamp": datetime.now(timezone.utc).isoformat(),
               "cwist_rps": cwist_rps, "cwist_lat_ms": cwist_lat, "cwist_p90_ms": cwist_p90, "cwist_p99_ms": cwist_p99, "cwist_p99_999_ms": cwist_p99_999, "cwist_rss_kib": cwist_rss, "cwist_csw": cwist_csw,
@@ -492,6 +517,10 @@ jobs:
               "axum_rps": axum_rps, "axum_lat_ms": axum_lat, "axum_p90_ms": axum_p90, "axum_p99_ms": axum_p99, "axum_p99_999_ms": axum_p99_999, "axum_rss_kib": axum_rss, "axum_csw": axum_csw,
               "gin_rps": gin_rps, "gin_lat_ms": gin_lat, "gin_p90_ms": gin_p90, "gin_p99_ms": gin_p99, "gin_p99_999_ms": gin_p99_999, "gin_rss_kib": gin_rss, "gin_csw": gin_csw,
               "spring_rps": spring_rps, "spring_lat_ms": spring_lat, "spring_p90_ms": spring_p90, "spring_p99_ms": spring_p99, "spring_p99_999_ms": spring_p99_999, "spring_rss_kib": spring_rss, "spring_csw": spring_csw,
+              # Same -t4 -c100 low-concurrency profile as cwist_tuned_*, added
+              # so a report comparing "tuned" numbers is comparing like with
+              # like instead of CWIST's best case against Spring's only case.
+              "spring_tuned_rps": spring_tuned_rps, "spring_tuned_lat_ms": spring_tuned_lat, "spring_tuned_p50_ms": spring_tuned_p50, "spring_tuned_p90_ms": spring_tuned_p90, "spring_tuned_p99_ms": spring_tuned_p99, "spring_tuned_p99_999_ms": spring_tuned_p99_999,
               "wrk_profile": os.environ.get("WRK_PROFILE", ""),
               "tuned_profile": os.environ.get("TUNED_PROFILE", ""),
               "runner_hw": os.environ.get("RUNNER_HW", ""),
@@ -515,7 +544,7 @@ jobs:
       - name: Copy raw benchmark output
         run: |
           mkdir -p raw_logs
-          cp /tmp/cwist.txt /tmp/cwist_stat.txt /tmp/cwist_c1m.txt /tmp/cwist_c1m_stat.txt /tmp/axum.txt /tmp/axum_stat.txt /tmp/gin.txt /tmp/gin_stat.txt /tmp/spring.txt /tmp/spring_stat.txt /tmp/spring_gc.log raw_logs/ 2>/dev/null || true
+          cp /tmp/cwist.txt /tmp/cwist_stat.txt /tmp/cwist_c1m.txt /tmp/cwist_c1m_stat.txt /tmp/cwist_tuned.txt /tmp/axum.txt /tmp/axum_stat.txt /tmp/gin.txt /tmp/gin_stat.txt /tmp/spring.txt /tmp/spring_stat.txt /tmp/spring_tuned.txt /tmp/spring_gc.log raw_logs/ 2>/dev/null || true
       - uses: actions/upload-artifact@v4
         with:
           name: webserver-result

--- a/docs/webserver-benchmark.md
+++ b/docs/webserver-benchmark.md
@@ -23,6 +23,17 @@ framework-specific tuning is applied beyond what is documented here.
 - **Context switches** (`nvcsw + nivcsw` from `ps`) are counted only over the measured
   window — the counter baseline is taken *after* warmup.
 
+### Tuned low-latency run
+
+CWIST and Spring Boot are each measured a second time under `wrk -t4 -c100 -d10s`
+(lower concurrency than the main `-t12 -c400` profile above), each in its own
+dedicated process — for Spring Boot this is a fresh boot replaying the same
+trained AOT cache used for its main run, so it isn't paying a second cold-start
+penalty CWIST doesn't pay either. This is CWIST's own published low-latency
+profile; giving Spring Boot the identical treatment keeps the "tuned" numbers
+comparable instead of showing CWIST's best case next to a number Spring was
+never measured at. Axum and Gin are not yet included in this second pass.
+
 ## CWIST
 
 - Built from the checked-out commit: `make`, then the bench server linked against

--- a/scripts/ci/benchmark.py
+++ b/scripts/ci/benchmark.py
@@ -206,14 +206,27 @@ def render() -> None:
     if README_MD.exists(): replace(README_MD, "<!-- WEBSERVER_BENCHMARKS:START -->", "<!-- WEBSERVER_BENCHMARKS:END -->", ws_summary)
 
     tuned_rps = ws_latest.get("cwist_tuned_rps")
+    spring_tuned_rps = ws_latest.get("spring_tuned_rps")
     if tuned_rps and README_MD.exists() and "<!-- TUNED_BENCHMARK:START -->" in README_MD.read_text():
-        tuned_profile = ws_latest.get("tuned_profile") or "CWIST_WORKERS sized to a pinned server core set, wrk pinned to the remaining cores"
+        tuned_profile = ws_latest.get("tuned_profile") or "wrk -t4 -c100 -d10s"
+        # Spring Boot gets the identical -t4 -c100 profile below (same
+        # trained AOT cache, same reduced concurrency) so this line compares
+        # like with like instead of showing only CWIST's best case next to
+        # Spring's single -c400 number in the table above.
         tuned_line = (
-            f"**Tuned low-latency run ({tuned_profile}): "
-            f"{tuned_rps:,.0f} req/s at {ws_latest.get('cwist_tuned_lat_ms',0):.2f}ms average latency "
+            f"**Tuned low-latency run ({tuned_profile}), CWIST vs Spring Boot on identical concurrency:**\n\n"
+            f"- **CWIST**: {tuned_rps:,.0f} req/s at {ws_latest.get('cwist_tuned_lat_ms',0):.2f}ms average latency "
             f"(P50 {ws_latest.get('cwist_tuned_p50_ms',0):.2f}ms, P90 {ws_latest.get('cwist_tuned_p90_ms',0):.2f}ms, "
-            f"P99 {ws_latest.get('cwist_tuned_p99_ms',0):.2f}ms).** "
-            f"Leaving headroom between server workers and load-generator threads keeps the latency tail flat — "
+            f"P99 {ws_latest.get('cwist_tuned_p99_ms',0):.2f}ms)\n"
+        )
+        if spring_tuned_rps:
+            tuned_line += (
+                f"- **Spring Boot**: {spring_tuned_rps:,.0f} req/s at {ws_latest.get('spring_tuned_lat_ms',0):.2f}ms average latency "
+                f"(P50 {ws_latest.get('spring_tuned_p50_ms',0):.2f}ms, P90 {ws_latest.get('spring_tuned_p90_ms',0):.2f}ms, "
+                f"P99 {ws_latest.get('spring_tuned_p99_ms',0):.2f}ms), same trained AOT cache as the main run above\n"
+            )
+        tuned_line += (
+            f"\nLeaving headroom between server workers and load-generator threads keeps the latency tail flat — "
             f"oversubscribing the same cores shows a multi-ms average from scheduling jitter alone at similar throughput."
         )
         replace(README_MD, "<!-- TUNED_BENCHMARK:START -->", "<!-- TUNED_BENCHMARK:END -->", tuned_line)


### PR DESCRIPTION
The web-server benchmark's "tuned low-latency run" (`wrk -t4 -c100`, vs the main `-t12 -c400` profile) was CWIST-only. It got published as a standalone README headline ("Tuned low-latency run: X req/s at Yms") with no Spring Boot equivalent anywhere nearby — so the comparison a reader would naturally make (tuned CWIST vs. the Spring Boot row in the table above) was CWIST's best case against a number Spring was never measured at. This also contradicted the doc's own "no framework gets a hand-tuned advantage the others do not get" claim.

## Fix
Spring Boot now gets an identical second boot under the identical `-t4 -c100 -d10s` profile, replaying the same trained AOT cache as its main run (no extra cold-start penalty CWIST doesn't also avoid). `spring_tuned_*` fields flow through the result JSON, and the README "Tuned low-latency run" section now shows CWIST and Spring Boot side by side instead of CWIST alone. `docs/webserver-benchmark.md` documents the methodology.

Axum/Gin are explicitly *not* included in this pass — noted in the doc as a known remaining asymmetry, out of scope here since this fix was specifically about the Spring Boot comparison.

## Verification
Not runnable outside GitHub Actions (needs JVM/Maven/Go/Rust toolchains + network setup the workflow provisions), so this was reviewed for correctness against the existing CWIST tuned-run code it mirrors rather than executed locally. `.github/workflows/bsd-kqueue-benchmarks.yml` parses clean with `yaml.safe_load`, `scripts/ci/benchmark.py` parses clean with `ast.parse`.