### PR TITLE
experiment(alloc): cap glibc arena count per worker (CWIST_MALLOC_ARENA_MAX)

### DIFF
--- a/.github/workflows/bsd-kqueue-benchmarks.yml
+++ b/.github/workflows/bsd-kqueue-benchmarks.yml
@@ -313,6 +313,15 @@ jobs:
           run_bench "CWIST (classic)" "env CWIST_C1M_MODE=0 /tmp/cwist_server" 9091 "/tmp/cwist.txt" "/tmp/cwist_stat.txt" 10
           run_bench "CWIST C1M" "env CWIST_C1M_MODE=1 /tmp/cwist_server" 9091 "/tmp/cwist_c1m.txt" "/tmp/cwist_c1m_stat.txt" 10
 
+          # Experimental: cap glibc's per-process malloc arena count to 1
+          # before the fork loop (src/sys/app/app.c), inherited by every
+          # worker (see issue #25's mimalloc writeup - this targets the same
+          # "N processes x M arenas" RSS/tail-latency multiplication mimalloc
+          # tried to fix, without mimalloc's eager per-process reservation).
+          # Same binary/config as "CWIST C1M" above; the env var is the only
+          # variable, so this is a direct A/B, not a new configuration.
+          run_bench "CWIST C1M (arena_max=1)" "env CWIST_C1M_MODE=1 CWIST_MALLOC_ARENA_MAX=1 /tmp/cwist_server" 9091 "/tmp/cwist_c1m_arena1.txt" "/tmp/cwist_c1m_arena1_stat.txt" 10
+
           # Tuned low-latency profile (CWIST classic only): lower connection
           # pressure (c100, 4 wrk threads) so the per-request latency floor is
           # visible alongside the c400 throughput numbers.
@@ -496,6 +505,9 @@ jobs:
           cwist_c1m_rps, cwist_c1m_lat, cwist_c1m_p50, cwist_c1m_p90, cwist_c1m_p99, cwist_c1m_p99_999 = parse_wrk("/tmp/cwist_c1m.txt")
           cwist_c1m_rss, cwist_c1m_csw = parse_stat("/tmp/cwist_c1m_stat.txt")
 
+          cwist_c1m_arena1_rps, cwist_c1m_arena1_lat, cwist_c1m_arena1_p50, cwist_c1m_arena1_p90, cwist_c1m_arena1_p99, cwist_c1m_arena1_p99_999 = parse_wrk("/tmp/cwist_c1m_arena1.txt")
+          cwist_c1m_arena1_rss, cwist_c1m_arena1_csw = parse_stat("/tmp/cwist_c1m_arena1_stat.txt")
+
           cwist_tuned_rps, cwist_tuned_lat, cwist_tuned_p50, cwist_tuned_p90, cwist_tuned_p99, cwist_tuned_p99_999 = parse_wrk("/tmp/cwist_tuned.txt")
 
           axum_rps, axum_lat, axum_p50, axum_p90, axum_p99, axum_p99_999 = parse_wrk("/tmp/axum.txt")
@@ -513,6 +525,9 @@ jobs:
               "timestamp": datetime.now(timezone.utc).isoformat(),
               "cwist_rps": cwist_rps, "cwist_lat_ms": cwist_lat, "cwist_p90_ms": cwist_p90, "cwist_p99_ms": cwist_p99, "cwist_p99_999_ms": cwist_p99_999, "cwist_rss_kib": cwist_rss, "cwist_csw": cwist_csw,
               "cwist_c1m_rps": cwist_c1m_rps, "cwist_c1m_lat_ms": cwist_c1m_lat, "cwist_c1m_p90_ms": cwist_c1m_p90, "cwist_c1m_p99_ms": cwist_c1m_p99, "cwist_c1m_p99_999_ms": cwist_c1m_p99_999, "cwist_c1m_rss_kib": cwist_c1m_rss, "cwist_c1m_csw": cwist_c1m_csw,
+              # Same C1M binary/config as cwist_c1m_* above, CWIST_MALLOC_ARENA_MAX=1 -
+              # only variable is the env var, direct A/B (see issue #25).
+              "cwist_c1m_arena1_rps": cwist_c1m_arena1_rps, "cwist_c1m_arena1_lat_ms": cwist_c1m_arena1_lat, "cwist_c1m_arena1_p90_ms": cwist_c1m_arena1_p90, "cwist_c1m_arena1_p99_ms": cwist_c1m_arena1_p99, "cwist_c1m_arena1_p99_999_ms": cwist_c1m_arena1_p99_999, "cwist_c1m_arena1_rss_kib": cwist_c1m_arena1_rss, "cwist_c1m_arena1_csw": cwist_c1m_arena1_csw,
               "cwist_tuned_rps": cwist_tuned_rps, "cwist_tuned_lat_ms": cwist_tuned_lat, "cwist_tuned_p50_ms": cwist_tuned_p50, "cwist_tuned_p90_ms": cwist_tuned_p90, "cwist_tuned_p99_ms": cwist_tuned_p99, "cwist_tuned_p99_999_ms": cwist_tuned_p99_999,
               "axum_rps": axum_rps, "axum_lat_ms": axum_lat, "axum_p90_ms": axum_p90, "axum_p99_ms": axum_p99, "axum_p99_999_ms": axum_p99_999, "axum_rss_kib": axum_rss, "axum_csw": axum_csw,
               "gin_rps": gin_rps, "gin_lat_ms": gin_lat, "gin_p90_ms": gin_p90, "gin_p99_ms": gin_p99, "gin_p99_999_ms": gin_p99_999, "gin_rss_kib": gin_rss, "gin_csw": gin_csw,
@@ -544,7 +559,7 @@ jobs:
       - name: Copy raw benchmark output
         run: |
           mkdir -p raw_logs
-          cp /tmp/cwist.txt /tmp/cwist_stat.txt /tmp/cwist_c1m.txt /tmp/cwist_c1m_stat.txt /tmp/cwist_tuned.txt /tmp/axum.txt /tmp/axum_stat.txt /tmp/gin.txt /tmp/gin_stat.txt /tmp/spring.txt /tmp/spring_stat.txt /tmp/spring_tuned.txt /tmp/spring_gc.log raw_logs/ 2>/dev/null || true
+          cp /tmp/cwist.txt /tmp/cwist_stat.txt /tmp/cwist_c1m.txt /tmp/cwist_c1m_stat.txt /tmp/cwist_c1m_arena1.txt /tmp/cwist_c1m_arena1_stat.txt /tmp/cwist_tuned.txt /tmp/axum.txt /tmp/axum_stat.txt /tmp/gin.txt /tmp/gin_stat.txt /tmp/spring.txt /tmp/spring_stat.txt /tmp/spring_tuned.txt /tmp/spring_gc.log raw_logs/ 2>/dev/null || true
       - uses: actions/upload-artifact@v4
         with:
           name: webserver-result

--- a/scripts/ci/benchmark.py
+++ b/scripts/ci/benchmark.py
@@ -166,6 +166,7 @@ def render() -> None:
 
     cwist_lat_part = get_lat_part("cwist")
     cwist_c1m_lat_part = get_lat_part("cwist_c1m")
+    cwist_c1m_arena1_lat_part = get_lat_part("cwist_c1m_arena1")
     axum_lat_part = get_lat_part("axum")
     gin_lat_part = get_lat_part("gin")
     spring_lat_part = get_lat_part("spring")
@@ -174,6 +175,7 @@ def render() -> None:
         f"Latest Web Server Benchmark ({ws_latest.get('wrk_profile','wrk 12t 400c')}):\n"
         f"- **CWIST (classic pool)**: {ws_latest.get('cwist_rps',0):.0f} req/s | Latency {ws_latest.get('cwist_lat_ms',0):.2f}ms{cwist_lat_part} | RSS {ws_latest.get('cwist_rss_kib',0):.0f}KiB | Csw {ws_latest.get('cwist_csw',0):.0f}\n"
         f"- **CWIST (C1M reactor)**: {ws_latest.get('cwist_c1m_rps',0):.0f} req/s | Latency {ws_latest.get('cwist_c1m_lat_ms',0):.2f}ms{cwist_c1m_lat_part} | RSS {ws_latest.get('cwist_c1m_rss_kib',0):.0f}KiB | Csw {ws_latest.get('cwist_c1m_csw',0):.0f}\n"
+        f"- **CWIST (C1M reactor, arena_max=1)** — experimental, see issue #25: {ws_latest.get('cwist_c1m_arena1_rps',0):.0f} req/s | Latency {ws_latest.get('cwist_c1m_arena1_lat_ms',0):.2f}ms{cwist_c1m_arena1_lat_part} | RSS {ws_latest.get('cwist_c1m_arena1_rss_kib',0):.0f}KiB | Csw {ws_latest.get('cwist_c1m_arena1_csw',0):.0f}\n"
         f"- **Axum**: {ws_latest.get('axum_rps',0):.0f} req/s | Latency {ws_latest.get('axum_lat_ms',0):.2f}ms{axum_lat_part} | RSS {ws_latest.get('axum_rss_kib',0):.0f}KiB | Csw {ws_latest.get('axum_csw',0):.0f}\n"
         f"- **Gin (Go)**: {ws_latest.get('gin_rps',0):.0f} req/s | Latency {ws_latest.get('gin_lat_ms',0):.2f}ms{gin_lat_part} | RSS {ws_latest.get('gin_rss_kib',0):.0f}KiB | Csw {ws_latest.get('gin_csw',0):.0f}\n"
         f"- **Spring Boot**: {ws_latest.get('spring_rps',0):.0f} req/s | Latency {ws_latest.get('spring_lat_ms',0):.2f}ms{spring_lat_part} | RSS {ws_latest.get('spring_rss_kib',0):.0f}KiB | Csw {ws_latest.get('spring_csw',0):.0f}\n"

--- a/src/sys/app/app.c
+++ b/src/sys/app/app.c
@@ -43,6 +43,9 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <poll.h>
+#if defined(__GLIBC__)
+#include <malloc.h>
+#endif
 #include <arpa/inet.h>
 #include <netinet/tcp.h>
 #include <dirent.h>
@@ -3734,6 +3737,36 @@ int cwist_app_listen(cwist_app *app, int port) {
         workers = (cores > 0) ? (int)cores : 1;
     }
     if (workers < 1) workers = 1;
+
+#if defined(__GLIBC__)
+    /* Experimental (issue #25, ROADMAP.md v3.5): cap glibc's per-process
+     * arena count before forking, so the setting is inherited by every
+     * worker. mallopt() state is plain process memory, not something a
+     * live fork() can "share back" afterward - COW means a child's first
+     * write to any inherited page (which malloc always does) forks its own
+     * private copy immediately, so there's no way to keep multiple
+     * processes pointed at one mutable arena. What *is* achievable is
+     * capping how many arenas each process can independently accumulate:
+     * by default glibc lets internal thread contention grow up to
+     * ncpus*8 arenas *per process* (each worker here forks before
+     * creating its own watcher/HTTP-3 threads, so every worker can hit
+     * that ceiling independently) - with N worker processes that's a
+     * multiplicative blow-up, and each extra arena is its own mmap'd
+     * region that adds directly to RSS. CWIST_MALLOC_ARENA_MAX=1 forces
+     * every worker down to its single main arena regardless of how many
+     * threads it spins up afterward. Unset by default: preserves today's
+     * behavior exactly. Not yet measured against the mimalloc A/B in that
+     * issue - this is the next experiment, not a default change. */
+    const char *arena_max_env = getenv("CWIST_MALLOC_ARENA_MAX");
+    if (arena_max_env && arena_max_env[0]) {
+        char *end = NULL;
+        long arena_max = strtol(arena_max_env, &end, 10);
+        if (end && *end == '\0' && arena_max >= 0 && arena_max <= INT_MAX) {
+            mallopt(M_ARENA_MAX, (int)arena_max);
+        }
+    }
+#endif
+
     bool is_worker_child = false;
     pid_t worker_pids[workers > 1 ? workers - 1 : 1];
     size_t worker_count = 0;


### PR DESCRIPTION
Follow-up to the mimalloc A/B in #25/#34, which regressed every metric there (RSS +120%, P99.999 +97%) because mimalloc eagerly reserves a large per-process arena to amortize over a long-lived process — a bad fit for CWIST's C1M mode (forks one process per core before creating any threads).

## What this does
Targets the same "N processes × M arenas" multiplication through **glibc's own allocator** instead of swapping in a new one. glibc's arena count is uncapped by default (up to `ncpus*8` on 64-bit) and grows per-process as internal threads contend for the main arena's lock — each C1M worker spins up its own watcher + HTTP/3 threads right after fork, so the same multiplication mimalloc has exists here too, just via thread contention instead of eager reservation, and with zero new dependency or upfront memory cost.

- `src/sys/app/app.c`: `mallopt(M_ARENA_MAX, N)` via `CWIST_MALLOC_ARENA_MAX`, called once before the fork loop in `cwist_app_listen()` so every worker inherits it. `mallopt` state is plain process memory — copied by `fork()` like everything else, no cross-process sharing trick needed (or possible: any inherited page gets private-copied on the child's first write regardless of what it is). **Unset by default: identical behavior to today.** Guarded `#if defined(__GLIBC__)` — `M_ARENA_MAX` is a glibc extension, not available on macOS/BSD malloc.
- CI: adds `CWIST C1M (arena_max=1)` right after `CWIST C1M` — same binary/config, the env var is the only variable, direct A/B. `scripts/ci/benchmark.py` renders it as its own README row.

## Not verified here
Local `wrk` runs on this branch were within this environment's own noise floor — the exact same local machine flip-flopped on which allocator won the mimalloc A/B too (see #34's comments), so a single local run here isn't worth reporting as a result. That's what this branch's actual CI run is for — same as #34, this PR is the A/B infrastructure, not a claimed win.
