### PR TITLE
fix(reactor): wake io_uring on cross-thread posts

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -34,6 +34,10 @@ jobs:
         make clean
         make -j$(nproc) SANITIZE=address,undefined WERROR=1
         make SANITIZE=address,undefined WERROR=1 test
+        # Do not let an unavailable io_uring backend silently validate only
+        # epoll: completion posting must wake the real ring without a timeout.
+        CWIST_TEST_REQUIRE_IO_URING=1 make SANITIZE=address,undefined WERROR=1 test_reactor_wake
+        CWIST_REACTOR_BACKEND=epoll make SANITIZE=address,undefined WERROR=1 test_reactor_wake
       env:
         ASAN_OPTIONS: detect_leaks=1:abort_on_error=1:halt_on_error=1
         LSAN_OPTIONS: suppressions=tests/lsan.supp

--- a/Makefile
+++ b/Makefile
@@ -453,7 +453,8 @@ $(CNATS_LIB):
 
 # --- Test Targets ---
 
-TEST_TARGETS = test_sstring \
+TEST_TARGETS = test_reactor_wake \
+               test_sstring \
                test_seq \
                test_seq_auth \
                test_http \
@@ -527,6 +528,12 @@ bench_security_pool: $(LIB_NAME) tests/bench_security_pool.c
 	./bench_security_pool
 
 test: $(TEST_TARGETS)
+
+# Kernel/queue contract test: use the real reactor with a test-only allocator,
+# without pulling HTTP/TLS or libttak runtime state into the wake-up schedule.
+test_reactor_wake: tests/test_reactor_wake.c src/sys/io/reactor.c
+	$(CC) $(CFLAGS) -o $@ tests/test_reactor_wake.c -pthread
+	./$@
 
 test_sstring: $(LIB_NAME) tests/test_sstring.c
 	$(CC) $(CFLAGS) -o test_sstring tests/test_sstring.c $(LIB_NAME) $(LIBS)

--- a/docs/reactor-wakeup-regression.md
+++ b/docs/reactor-wakeup-regression.md
@@ -1,0 +1,84 @@
+# io_uring posted-work wake-up regression (#25)
+
+## Scope and cause
+
+This fixes a wake-up regression present in `dev` at
+`6afc4a3a506e6740d93ebb2630de917fafd7dea9`, introduced by `7a67f87d`.
+It is a partial contribution to [#25](https://github.com/c4punks/CWIST/issues/25),
+not evidence that the original HTTP concurrency-64/256/512 P99.999 problem is
+fully resolved.
+
+`IORING_REGISTER_EVENTFD` sends **completion notifications from the ring to an
+eventfd**. Writing that eventfd does not enqueue a CQE or wake a ring waiting
+for completions. The previous code used it in the opposite direction and
+removed the wake fd's input poll. With no unrelated socket activity, posted
+work could therefore wait for the run loop's 100 ms shutdown-check timeout.
+A registered eventfd notification also does not synthesize a CQE with
+`user_data == 0`.
+
+The fix restores the one-shot input poll and its existing callback/re-arm path
+on io_uring. Empty-to-nonempty post-stack wake coalescing remains enabled.
+No public API or connection layout changes are involved.
+
+References:
+
+- [io_uring_register(2), IORING_REGISTER_EVENTFD](https://man7.org/linux/man-pages/man2/io_uring_register.2.html)
+- [io_uring_register_eventfd(3)](https://man7.org/linux/man-pages/man3/io_uring_register_eventfd.3.html)
+
+## Regression test
+
+`test_reactor_wake` compiles the production reactor with a test-only libc
+allocator and shutdown flag. It does not replace kernel polling, eventfd,
+posting, or dispatch. It needs the checked-out libttak headers but does not
+link the HTTP/TLS stack or the libttak allocator runtime.
+
+On io_uring it posts four batches of 128 nodes from a foreign thread, requires
+an actual kernel completion on each batch, and runs production dispatch between
+batches to exercise re-arming. A timeout cannot substitute for a completion;
+a positive submission count alone is not sufficient either. An idle-ring check
+rejects completion-to-eventfd feedback. On all supported backends a further 64
+foreign-thread posts verify exactly-once FIFO delivery on the reactor owner.
+A 30-second alarm is only a hang watchdog, not a performance acceptance gate.
+
+```sh
+git submodule update --init lib/libttak
+CWIST_TEST_REQUIRE_IO_URING=1 make WERROR=1 test_reactor_wake
+CWIST_REACTOR_BACKEND=epoll make WERROR=1 test_reactor_wake
+CWIST_TEST_REQUIRE_IO_URING=1 make WERROR=1 SANITIZE=address,undefined test_reactor_wake
+CWIST_REACTOR_BACKEND=epoll make WERROR=1 SANITIZE=address,undefined test_reactor_wake
+# macOS, native kqueue:
+make CC=clang WERROR=1 SANITIZE=address,undefined test_reactor_wake
+```
+
+Run Linux commands on a host that permits `io_uring_setup`; a container seccomp
+policy may prohibit it. The required-backend variable makes this an explicit
+failure instead of silently testing epoll. Do not retain that variable when
+intentionally testing epoll. The sanitizer CI workflow explicitly tests both
+Linux backends in addition to the existing full suite.
+
+## Component measurement (2026-09-12)
+
+Environment: Linux `6.8.0-117-generic`, GCC `13.3.0`, x86_64 Colima/QEMU guest
+on an ARM64 Mac, 6 configured vCPUs and 12 GiB RAM. This is a shared, emulated
+VM, not a production throughput benchmark. Each binary was built using the
+same test and `-std=gnu11 -O2 -g -Wall -Wextra -Werror -pthread`; only the reactor
+source differed. `--bench` skips the deliberately failing kernel regression
+gate and records `CLOCK_MONOTONIC` time from immediately before posting to
+callback execution. No explicit warm-up, no sockets, one producer and one
+reactor, one sequential outstanding post. The existing 100 ms run-loop timeout
+was unchanged.
+
+Three paired runs, 64 samples each per binary, ordered base/fixed,
+fixed/base, base/fixed:
+
+- Base run medians: 103.955, 103.537, 103.490 ms.
+- Fixed run medians: 0.033433, 0.036471, 0.038093 ms.
+- Across 192 samples per binary, base median/max: 103.787046 / 109.251727 ms.
+- Across 192 samples per binary, fixed median/max: 0.034446 / 0.273538 ms.
+
+The regression gate fails against the base with
+`posted wake did not generate a completion: Timer expired` and passes after
+the fix. Targeted ASan/UBSan checks pass on Linux io_uring, forced epoll, and
+native macOS kqueue. These are component checks, not allocator integration,
+HTTP throughput, or P99.999 measurements. The original issue's HTTP workload
+and production hardware still require separate end-to-end validation.

--- a/src/sys/io/reactor.c
+++ b/src/sys/io/reactor.c
@@ -55,9 +55,6 @@ static inline int sys_io_uring_enter_timeout(int ring_fd, unsigned to_submit, un
     return (int)syscall(__NR_io_uring_enter, ring_fd, to_submit, min_complete,
                         flags | IORING_ENTER_EXT_ARG, &arg, sizeof(arg));
 }
-static inline int sys_io_uring_register(int ring_fd, unsigned opcode, const void *arg, unsigned nr) {
-    return (int)syscall(__NR_io_uring_register, ring_fd, opcode, arg, nr);
-}
 
 /* Ring setup helpers absorbed from the retired io_uring_backend.c. */
 static void *mmap_ring(int fd, size_t sz, off_t off) {
@@ -96,10 +93,6 @@ typedef struct {
     // epoll fallback
     int epoll_fd;
     bool use_epoll;
-    /* True when wake_fd is registered via IORING_REGISTER_EVENTFD: writes
-     * then post CQEs directly, so the wake fd consumes no one-shot poll
-     * slot and needs no re-arm. */
-    bool wake_registered;
 } reactor_impl_t;
 
 #elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
@@ -221,10 +214,8 @@ bool cwist_reactor_post(cwist_reactor_t *r, cwist_reactor_post_t *node) {
         node->next = head;
     } while (!atomic_compare_exchange_weak_explicit(&r->post_head, &head, node,
                                                     memory_order_release, memory_order_relaxed));
-    /* Wake only on the first post of a pending batch: if the stack was
-     * non-empty a wake CQE is already in flight (or the run thread is
-     * mid-drain and will re-check at the loop top), so extra writes would
-     * only flood the ring with redundant eventfd CQEs. */
+    /* Wake only on the first post of a pending batch. A non-empty stack
+     * already has a wake pending; another write would be redundant. */
     if (head == NULL && r->wake_wr >= 0) {
         uint64_t one = 1;
         ssize_t ign = write(r->wake_wr, &one, sizeof(one));
@@ -312,20 +303,6 @@ cwist_reactor_t *cwist_reactor_create(void) {
             r->impl.cq_entries      = p.cq_entries;
             r->impl.active = true;
 
-            /* Register the wake eventfd with the ring itself: writes post
-             * CQEs directly (user_data == 0), so the wake fd consumes no
-             * one-shot poll slot and needs no re-arm per firing.  On any
-             * failure fall back to the polled wake fd below. */
-            r->wake_fd = eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
-            if (r->wake_fd >= 0 &&
-                sys_io_uring_register(fd, IORING_REGISTER_EVENTFD, &r->wake_fd, 1) == 0) {
-                r->wake_wr = r->wake_fd;
-                r->impl.wake_registered = true;
-            } else if (r->wake_fd >= 0) {
-                close(r->wake_fd);
-                r->wake_fd = -1;
-            }
-
             /* Identity SQE mapping is fixed for the ring's lifetime; fill it
              * once here instead of rewriting sq_array on every submission. */
             for (uint32_t i = 0; i < p.sq_entries; i++) r->impl.sq_array[i] = i;
@@ -358,10 +335,8 @@ cwist_reactor_t *cwist_reactor_create(void) {
 #endif
     atomic_init(&r->post_head, NULL);
 #ifdef __linux__
-    if (!r->impl.wake_registered) {
-        r->wake_fd = eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
-        r->wake_wr = r->wake_fd;
-    }
+    r->wake_fd = eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
+    r->wake_wr = r->wake_fd;
 #else
     r->wake_fd = -1;
     r->wake_wr = -1;
@@ -377,12 +352,11 @@ cwist_reactor_t *cwist_reactor_create(void) {
         }
     }
 #endif
-#ifdef __linux__
-    bool wake_polled = !r->impl.wake_registered;
-#else
-    bool wake_polled = true;
-#endif
-    if (wake_polled && r->wake_fd >= 0 &&
+    /* Poll the wake fd on every backend. IORING_REGISTER_EVENTFD notifies
+     * an external eventfd when CQEs arrive; writes to it do not create CQEs
+     * or interrupt io_uring_enter. The one-shot poll is re-armed by
+     * reactor_wake_cb, including when posts arrive during a dispatch. */
+    if (r->wake_fd >= 0 &&
         !cwist_reactor_add(r, r->wake_fd, reactor_wake_cb, &r, sizeof(r))) {
         /* Wake best-effort: the run loop still drains the stack each round. */
         close(r->wake_fd);
@@ -729,11 +703,6 @@ void cwist_reactor_run(cwist_reactor_t *reactor) {
                         ev_ctx->cb(ev_ctx->fd, ev_ctx->ctx);
                     }
                     free_reactor_ctx(reactor, ev_ctx);
-                } else if (reactor->impl.wake_registered) {
-                    /* Registered eventfd CQE (user_data == 0): drain the
-                     * counter; the posts themselves run at the loop top. */
-                    uint64_t buf[8];
-                    while (read(reactor->wake_fd, buf, sizeof(buf)) > 0) {}
                 }
                 head++;
             }

--- a/tests/test_reactor_wake.c
+++ b/tests/test_reactor_wake.c
@@ -1,0 +1,183 @@
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+/* Standalone reactor/kernel contract test. Include the implementation to
+ * reject io_uring fallback and inspect completion readiness, without adding a
+ * public test API. Only the allocator and process shutdown flag are replaced;
+ * all polling, eventfd, posting, and run-loop code is production code.
+ *
+ * --bench prints post-to-callback samples; timings are diagnostic, not gates.
+ * CWIST_TEST_REQUIRE_IO_URING=1 fails rather than skipping a denied backend.
+ */
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include "../src/sys/io/reactor.c"
+
+void *cwist_alloc(size_t size) { return calloc(1, size); }
+void cwist_free(void *ptr) { free(ptr); }
+atomic_int g_cwist_running = 1;
+
+enum { ROUNDS = 64, BATCH = 128 };
+static cwist_reactor_t *loop;
+static pthread_t owner;
+static cwist_reactor_post_t chain[ROUNDS], finish;
+static struct timespec sent[ROUNDS];
+static double elapsed[ROUNDS];
+static int delivered;
+static pthread_mutex_t mu = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t cv = PTHREAD_COND_INITIALIZER;
+static int requested = -1;
+static bool quitting;
+
+static double milliseconds(struct timespec a, struct timespec b) {
+    return (b.tv_sec - a.tv_sec) * 1000.0 + (b.tv_nsec - a.tv_nsec) / 1e6;
+}
+
+static void noop(void *ctx) { (void)ctx; }
+
+static void request_next(int index) {
+    assert(pthread_mutex_lock(&mu) == 0);
+    requested = index;
+    assert(pthread_cond_signal(&cv) == 0);
+    assert(pthread_mutex_unlock(&mu) == 0);
+}
+
+static void delivered_cb(void *ctx) {
+    int index = (int)(intptr_t)ctx;
+    struct timespec now;
+    assert(pthread_equal(pthread_self(), owner));
+    assert(index == delivered++);
+    assert(clock_gettime(CLOCK_MONOTONIC, &now) == 0);
+    elapsed[index] = milliseconds(sent[index], now);
+    if (index + 1 < ROUNDS) {
+        request_next(index + 1);
+    } else {
+        cwist_reactor_stop(loop);
+        /* stop() does not wake a wait after the top-of-loop post drain.
+         * Queue a final no-op so this test is not about that separate API. */
+        finish.cb = noop;
+        assert(cwist_reactor_post(loop, &finish));
+    }
+}
+
+static void *producer(void *unused) {
+    (void)unused;
+    for (;;) {
+        assert(pthread_mutex_lock(&mu) == 0);
+        while (requested < 0 && !quitting)
+            assert(pthread_cond_wait(&cv, &mu) == 0);
+        if (quitting) {
+            assert(pthread_mutex_unlock(&mu) == 0);
+            return NULL;
+        }
+        int index = requested;
+        requested = -1;
+        assert(pthread_mutex_unlock(&mu) == 0);
+        chain[index].cb = delivered_cb;
+        chain[index].ctx = (void *)(intptr_t)index;
+        assert(clock_gettime(CLOCK_MONOTONIC, &sent[index]) == 0);
+        assert(cwist_reactor_post(loop, &chain[index]));
+    }
+}
+
+#ifdef __linux__
+static void burst_cb(void *ctx) {
+    assert(pthread_equal(pthread_self(), owner));
+    assert((int)(intptr_t)ctx == delivered++);
+    if (delivered == BATCH) cwist_reactor_stop(loop);
+}
+
+static void *burst_producer(void *arg) {
+    cwist_reactor_post_t *nodes = arg;
+    for (int i = 0; i < BATCH; i++) {
+        nodes[i].cb = burst_cb;
+        nodes[i].ctx = (void *)(intptr_t)i;
+        assert(cwist_reactor_post(loop, &nodes[i]));
+    }
+    return NULL;
+}
+#endif
+
+/* A readable post wake must produce a completion, not merely become visible
+ * at the next shutdown polling timeout. No sockets can rescue the wake here.
+ * Repeat on the same ring, using production dispatch to consume/re-arm it. */
+static void check_uring_wake(void) {
+#ifdef __linux__
+    if (loop->impl.use_epoll) return;
+    for (int epoch = 0; epoch < 4; epoch++) {
+        cwist_reactor_post_t nodes[BATCH] = {0};
+        pthread_t thread;
+        delivered = 0;
+        assert(pthread_create(&thread, NULL, burst_producer, nodes) == 0);
+        assert(pthread_join(thread, NULL) == 0);
+        const struct __kernel_timespec deadline = { .tv_sec = 1 };
+        int ret;
+        do {
+            ret = sys_io_uring_enter_timeout(loop->impl.ring_fd,
+                        loop->sq_unsubmitted, 1, IORING_ENTER_GETEVENTS, &deadline);
+        } while (ret < 0 && errno == EINTR);
+        if (ret < 0) {
+            perror("posted wake did not generate a completion");
+            exit(1);
+        }
+        loop->sq_unsubmitted = 0;
+        /* A positive submission count can mask a wait timeout. Require a
+         * real CQE too, including after each production dispatch/re-arm. */
+        assert(__atomic_load_n(loop->impl.cq_tail, __ATOMIC_ACQUIRE) !=
+               __atomic_load_n(loop->impl.cq_head, __ATOMIC_ACQUIRE));
+        cwist_reactor_run(loop);
+        assert(delivered == BATCH);
+    }
+    /* The drained input poll must be idle. Retaining output registration on
+     * the same fd could otherwise feed completions back into themselves. */
+    const struct __kernel_timespec idle = { .tv_nsec = 10000000 };
+    (void)sys_io_uring_enter_timeout(loop->impl.ring_fd,
+                    loop->sq_unsubmitted, 1, IORING_ENTER_GETEVENTS, &idle);
+    loop->sq_unsubmitted = 0;
+    assert(__atomic_load_n(loop->impl.cq_tail, __ATOMIC_ACQUIRE) ==
+           __atomic_load_n(loop->impl.cq_head, __ATOMIC_ACQUIRE));
+#endif
+}
+
+static cwist_reactor_t *create_checked(void) {
+    cwist_reactor_t *r = cwist_reactor_create();
+    assert(r != NULL);
+#ifdef __linux__
+    printf("backend=%s\n", r->impl.use_epoll ? "epoll" : "io_uring");
+    if (r->impl.use_epoll && getenv("CWIST_TEST_REQUIRE_IO_URING")) {
+        fprintf(stderr, "required io_uring backend unavailable\n");
+        cwist_reactor_destroy(r);
+        exit(1);
+    }
+#else
+    puts("backend=kqueue");
+#endif
+    return r;
+}
+
+int main(int argc, char **argv) {
+    bool bench = argc == 2 && strcmp(argv[1], "--bench") == 0;
+    alarm(30); /* Watchdog only, not the correctness oracle. */
+    owner = pthread_self();
+    loop = create_checked();
+    if (!bench) check_uring_wake();
+    cwist_reactor_destroy(loop);
+    loop = create_checked();
+    delivered = 0;
+    pthread_t thread;
+    assert(pthread_create(&thread, NULL, producer, NULL) == 0);
+    request_next(0);
+    cwist_reactor_run(loop);
+    assert(pthread_mutex_lock(&mu) == 0);
+    quitting = true;
+    assert(pthread_cond_signal(&cv) == 0);
+    assert(pthread_mutex_unlock(&mu) == 0);
+    assert(pthread_join(thread, NULL) == 0);
+    assert(delivered == ROUNDS);
+    cwist_reactor_destroy(loop);
+    for (int i = 0; i < ROUNDS; i++) printf("post_ms[%d]=%.6f\n", i, elapsed[i]);
+    puts("reactor wake, repeated re-arm, FIFO and owner-thread delivery: PASS");
+    return 0;
+}


### PR DESCRIPTION
## Summary

Related to #25 — **partial fix, do not close the original issue**.

Fix the io_uring posted-work wake-up regression introduced by `7a67f87d` and still present in `dev` at `6afc4a3a`.

`IORING_REGISTER_EVENTFD` notifies an external eventfd **when ring completions arrive**; writing that fd does not generate a CQE or wake `io_uring_enter`. Removing the input poll therefore leaves posted work waiting for the existing 100 ms shutdown-check timeout when no unrelated socket event arrives. The old zero-user-data "registered eventfd CQE" handling is also incorrect: registration does not synthesize such CQEs.

- Restore the existing one-shot input poll and production wake callback/re-arm path.
- Preserve empty-to-nonempty post wake coalescing; no public API/layout changes.
- Add a standalone real-kernel regression target, registered in `make test`.
- Require actual io_uring and separately force epoll in sanitizer CI, so fallback cannot silently validate the wrong backend.
- Document the mechanism, exact test scope, and component measurements in `docs/reactor-wakeup-regression.md`.

## Evidence

Actual Linux 6.8.0-117-generic io_uring, GCC 13.3.0:

- **RED:** final regression test against the base exits 1: `posted wake did not generate a completion: Timer expired`.
- **GREEN:** four batches of 128 foreign-thread posts require real CQEs across repeated production dispatch/re-arm epochs; idle CQ and 64-post FIFO/owner-thread checks pass.
- `CWIST_TEST_REQUIRE_IO_URING=1 make SANITIZE=address,undefined WERROR=1 test_reactor_wake` — PASS.
- `CWIST_REACTOR_BACKEND=epoll make SANITIZE=address,undefined WERROR=1 test_reactor_wake` — PASS.
- Native macOS kqueue, `make CC=clang SANITIZE=address,undefined WERROR=1 test_reactor_wake` — PASS, also independently reproduced by the reviewer.
- Independent source/security/test review: approved the bounded repair, no blocking candidate finding.

Three paired component runs, 64 samples per binary per run (192 each), alternating run order:

- Post-to-callback median: **103.787046 ms → 0.034446 ms**.
- Observed maximum: **109.251727 ms → 0.273538 ms**.

These are one-producer/one-reactor, no-socket component measurements on an x86_64 Colima/QEMU VM hosted on ARM64, with no explicit warm-up. The test substitutes only the allocator with calloc/free; kernel readiness and production reactor code are real. Benchmark compilation uses identical `-O2` flags for base and candidate. Timing values are diagnostic, not fragile correctness thresholds.

## Limits / follow-up

- **Not a claim that the original HTTP concurrency-64/256/512 P99.999 workload is resolved.** No HTTP throughput or P99.999 result is inferred from 192 component samples.
- Local full-library/HTTP integration suite was not run; targeted builds need only the libttak headers. Hosted CI/full-suite status is separate and must pass before merge.
- Existing stop synchronization, error-path wake-fd invalidation, wake-write EINTR handling, and broader race/fault-injection coverage are not redesigned by this bounded restoration.

References: [io_uring_register(2)](https://man7.org/linux/man-pages/man2/io_uring_register.2.html), [io_uring_register_eventfd(3)](https://man7.org/linux/man-pages/man3/io_uring_register_eventfd.3.html).
