### PR TITLE
fix(http): prevent classic-pool connection starvation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -453,7 +453,8 @@ $(CNATS_LIB):
 
 # --- Test Targets ---
 
-TEST_TARGETS = test_sstring \
+TEST_TARGETS = test_classic_pool_scaling \
+               test_sstring \
                test_seq \
                test_seq_auth \
                test_http \
@@ -527,6 +528,13 @@ bench_security_pool: $(LIB_NAME) tests/bench_security_pool.c
 	./bench_security_pool
 
 test: $(TEST_TARGETS)
+
+test_classic_pool_scaling: $(LIB_NAME) tests/test_classic_pool_scaling.c
+	$(CC) $(CFLAGS) -o $@ tests/test_classic_pool_scaling.c $(LIB_NAME) $(LIBS)
+	./$@ burst
+	./$@ multi
+	./$@ cap
+	./$@ failure
 
 test_sstring: $(LIB_NAME) tests/test_sstring.c
 	$(CC) $(CFLAGS) -o test_sstring tests/test_sstring.c $(LIB_NAME) $(LIBS)

--- a/docs/classic-pool-starvation.md
+++ b/docs/classic-pool-starvation.md
@@ -1,0 +1,94 @@
+# Classic pool burst starvation (#25 follow-up)
+
+This is a liveness repair, not a claim that the original HTTP P99.999 report
+has been resolved. It is independent of the io_uring wake-up repair in #37.
+
+## Cause and change
+
+A condition-variable worker remains counted as idle until it wakes and
+reacquires the queue mutex. Previously, submission only grew the classic
+pool when `idle_workers == 0`. A burst could queue several connections while
+one signalled worker still counted idle; once it started a long-lived
+keep-alive handler, the remaining connections had no worker and no further
+submission to trigger growth.
+
+Submission now compares **queued demand against idle capacity** under the
+queue mutex. The maximum-worker check and thread reservation occur in that
+same critical section, so concurrent submitters cannot reserve the same
+remaining slot. It still attempts at most one growth per submission and
+keeps the existing two-attempt thread-creation failure rollback.
+
+No pool defaults, public interfaces, reactor backend, allocator, or pipeline
+budget change. Failed creation can still leave work for existing workers;
+this does not promise progress when resources are exhausted and every
+existing handler is blocked. Existing detached-worker shutdown behavior is
+outside this repair.
+
+## Deterministic regression
+
+`make WERROR=1 test_classic_pool_scaling` runs four separate processes:
+
+- One delayed idle worker and eight held handlers: all eight must start
+  **before any handler completes**. The old code starts only one.
+- Three delayed idle workers: the burst still needs eight concurrent entries.
+- Concurrent submitters with a four-worker cap: no cap overshoot; all eight
+  tasks finish once the four active handlers are released.
+- Two injected `pthread_create` failures: one reservation rolls back, seven
+  handlers can start, and all eight finish after release.
+
+The harness executes production queue code. It delays the condition-wait
+reacquisition and makes captured worker threads joinable solely for safe test
+cleanup; it does not claim to test production detached-worker shutdown.
+The test is included in the normal `make test` suite.
+
+## Validation status
+
+On the local ARM64 Linux environment, the `-Werror` build succeeded. Running
+all 57 Makefile test targets with `make -k WERROR=1 test` produced 56 passes
+and one failure: `test_grpc.c:243`, the `append_grpc_string_frame` append
+assertion. Rebuilding with the original `dev` HTTP source reproduced the same
+failure. This is an observed pre-existing failure in this environment, not a
+claim that its underlying cause is understood or that the full suite is green.
+
+A clean ASan/UBSan build passed these six targets, with leak detection enabled
+and the repository's existing LSan suppression file:
+`test_classic_pool_scaling`, `test_http`, `test_http_pipeline`,
+`test_http_fairness`, `test_async_defer`, and `test_conn_registry`.
+The four pool modes all passed. Independent static review found no blocking
+candidate defect. Hosted CI must still be reviewed; this remains a draft
+until the outstanding validation concerns are resolved.
+
+## HTTP measurements and limits
+
+Local measurements used a dedicated ARM64 Linux VM (4 vCPUs, 4 GiB, kernel
+6.8.0-117), the repository's fixed empty-GET benchmark, four classic worker
+processes, two load-generator threads, and an FD limit of 65536. Each measured
+20-second run followed 5 seconds of discarded warmup. Three paired rounds at
+64, 256 and 512 connections produced 18 error-free runs after correcting the
+measurement clock. Both sides had #37 applied; this patch changes only the
+classic pool, which does not use that reactor wake-up path.
+
+wrk 4.2.0 (`a211dd5a7050b1f9e8a9870b95513060e72ac4a0`) was built locally
+with its `time_us()` using `clock_gettime(CLOCK_MONOTONIC)` instead of
+`gettimeofday`. Initial system-wrk results were discarded: Lima clock-sync
+logs showed backwards wall-clock steps, and wrk's unsigned latency subtraction
+can classify those as histogram-overflow timeouts. This is a measurement-tool
+adjustment, not a server optimization. wrk's reported percentiles also include
+its built-in synthetic latency correction, not only raw observations.
+
+P99.999 in milliseconds, all three runs (before → after):
+
+- c64: `3.194, 3.185, 3.168` → `5.576, 3.172, 3.160`
+- c256: `3.707, 3.583, 3.573` → `3.690, 3.623, 3.616`
+- c512: `4.256, 4.172, 4.173` → `4.276, 4.165, 4.266`
+
+**No consistent steady-state P99.999 reduction was established.** The c64
+candidate outlier is retained, not hidden. Throughput ranges overlap. Separate
+uncontrolled real-HTTP connection bursts also completed on both versions;
+those runs did not reproduce the held-worker schedule from the deterministic
+test. Completed-request histograms alone cannot prove progress for requests
+that never complete. The original issue's 645.72 ms result has not been
+reproduced with this different hardware, revision and workload setup.
+
+References: [wrk timer and timeout accounting](https://github.com/wg/wrk/blob/4.2.0/src/wrk.c),
+[wrk statistics correction](https://github.com/wg/wrk/blob/4.2.0/src/stats.c).

--- a/src/net/http/http.c
+++ b/src/net/http/http.c
@@ -441,16 +441,20 @@ void cwist_http_pool_submit(int client_fd, void (*handler)(int, void *), void *c
         g_dyn_pool.tail->next = node;
         g_dyn_pool.tail = node;
     }
-    atomic_fetch_add_explicit(&g_dyn_pool.pending_tasks, 1, memory_order_release);
-    pthread_cond_signal(&g_dyn_pool.cond);
-    pthread_mutex_unlock(&g_dyn_pool.lock);
+    long pending = atomic_fetch_add_explicit(&g_dyn_pool.pending_tasks, 1, memory_order_release) + 1;
 
+    /* Signalled sleepers remain counted idle until they reacquire this lock.
+     * Compare queued demand with that capacity, not merely idle == 0: a
+     * burst can otherwise strand connections behind busy keep-alive handlers.
+     * Keep the cap check and the spawn reservation in this critical section. */
     long current = atomic_load_explicit(&g_dyn_pool.active_workers, memory_order_relaxed);
     long idle = atomic_load_explicit(&g_dyn_pool.idle_workers, memory_order_relaxed);
     long max_w = atomic_load_explicit(&g_dyn_pool.max_workers, memory_order_relaxed);
-    if (idle == 0 && current < max_w) {
+    if (pending > idle && current < max_w) {
         http_spawn_worker();
     }
+    pthread_cond_signal(&g_dyn_pool.cond);
+    pthread_mutex_unlock(&g_dyn_pool.lock);
 }
 
 bool cwist_http_pool_rearm_current(int client_fd, void (*handler)(int, void *), void *ctx) {

--- a/tests/test_classic_pool_scaling.c
+++ b/tests/test_classic_pool_scaling.c
@@ -27,7 +27,9 @@ static int joinable_create(pthread_t *, const pthread_attr_t *,
 #define MAX_THREADS (JOBS * 4)
 static pthread_mutex_t gate_mu = PTHREAD_MUTEX_INITIALIZER;
 static pthread_cond_t gate_cv = PTHREAD_COND_INITIALIZER;
-static bool initial_parked, release_initial, release_handlers;
+static int initial_parked, initial_threads = 1;
+static bool release_initial, release_handlers;
+static int fail_creates, failed_creates;
 static int started, finished;
 static bool seen[JOBS];
 static pthread_t threads[MAX_THREADS];
@@ -43,8 +45,8 @@ static struct timespec deadline(void) {
 static int delayed_wait(pthread_cond_t *cond, pthread_mutex_t *mutex) {
     if (cond == &g_dyn_pool.cond) {
         pthread_mutex_lock(&gate_mu);
-        if (!initial_parked) {
-            initial_parked = true;
+        if (initial_parked < initial_threads) {
+            initial_parked++;
             pthread_mutex_unlock(mutex);
             pthread_cond_broadcast(&gate_cv);
             while (!release_initial) pthread_cond_wait(&gate_cv, &gate_mu);
@@ -59,6 +61,14 @@ static int delayed_wait(pthread_cond_t *cond, pthread_mutex_t *mutex) {
 
 static int joinable_create(pthread_t *thread, const pthread_attr_t *attr,
                            void *(*start)(void *), void *arg) {
+    pthread_mutex_lock(&gate_mu);
+    if (fail_creates) {
+        fail_creates--;
+        failed_creates++;
+        pthread_mutex_unlock(&gate_mu);
+        return EAGAIN;
+    }
+    pthread_mutex_unlock(&gate_mu);
     pthread_attr_t joinable;
     assert(pthread_attr_init(&joinable) == 0);
     size_t stack_size;
@@ -89,8 +99,19 @@ static void held_handler(int fd, void *ctx) {
     pthread_mutex_unlock(&gate_mu);
 }
 
-int main(void) {
+static void *submit_one(void *id) {
+    cwist_http_pool_submit(-1, held_handler, id);
+    return NULL;
+}
+
+int main(int argc, char **argv) {
     alarm(15);
+    const char *mode = argc > 1 ? argv[1] : "burst";
+    bool capped = strcmp(mode, "cap") == 0;
+    bool failure = strcmp(mode, "failure") == 0;
+    initial_threads = strcmp(mode, "multi") == 0 ? 3 : 1;
+    int expected = capped ? 4 : failure ? JOBS - 1 : JOBS;
+    cwist_http_pool_limit_core((unsigned int)initial_threads);
     assert(setenv("CWIST_C1M_MODE", "0", 1) == 0);
     assert(setenv("CWIST_WORKER_THREADS", "1", 1) == 0);
     assert(setenv("CWIST_POOL_IDLE_TIMEOUT_MS", "0", 1) == 0);
@@ -98,23 +119,28 @@ int main(void) {
     assert(cwist_http_pool_init() == 0);
     pthread_mutex_lock(&gate_mu);
     struct timespec until = deadline();
-    while (!initial_parked) {
+    while (initial_parked < initial_threads) {
         int rc = pthread_cond_timedwait(&gate_cv, &gate_mu, &until);
         assert(rc == 0);
     }
+    if (capped) atomic_store(&g_dyn_pool.max_workers, 4);
+    if (failure) fail_creates = 2;
     pthread_mutex_unlock(&gate_mu);
 
     int ids[JOBS];
+    pthread_t submitters[JOBS];
     for (int i = 0; i < JOBS; i++) {
         ids[i] = i;
         /* The handler owns no transport in this queue-only regression. */
-        cwist_http_pool_submit(-1, held_handler, &ids[i]);
+        if (capped) assert(pthread_create(&submitters[i], NULL, submit_one, &ids[i]) == 0);
+        else submit_one(&ids[i]);
     }
+    if (capped) for (int i = 0; i < JOBS; i++) assert(pthread_join(submitters[i], NULL) == 0);
     pthread_mutex_lock(&gate_mu);
     release_initial = true;
     pthread_cond_broadcast(&gate_cv);
     until = deadline();
-    while (started < JOBS) {
+    while (started < expected) {
         int rc = pthread_cond_timedwait(&gate_cv, &gate_mu, &until);
         if (rc == ETIMEDOUT) break;
         assert(rc == 0);
@@ -138,10 +164,13 @@ int main(void) {
     for (int i = 0; i < thread_count; i++) assert(pthread_join(threads[i], NULL) == 0);
     assert(atomic_load(&g_http_inflight) == 0);
     assert(atomic_load(&g_dyn_pool.pending_tasks) == 0);
+    assert(atomic_load(&g_dyn_pool.active_workers) == thread_count);
+    if (capped) assert(thread_count <= 4);
+    if (failure) assert(failed_creates == 2 && fail_creates == 0);
     cwist_http_pool_destroy();
     printf("classic burst: %d/%d handlers started before any completion; workers=%d\n",
            started_without_release, JOBS, thread_count);
-    if (started_without_release != JOBS) {
+    if (started_without_release != expected) {
         fputs("FAIL: queued connections starve behind held keep-alive handlers\n", stderr);
         return 1;
     }

--- a/tests/test_classic_pool_scaling.c
+++ b/tests/test_classic_pool_scaling.c
@@ -1,0 +1,150 @@
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+#include <assert.h>
+#include <errno.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include <unistd.h>
+
+/* Hold the first idle worker after its condition wait released the queue
+ * mutex. This models a signalled worker that has not been scheduled yet.
+ * Make pool threads joinable only in this harness so no detached worker can
+ * outlive the synchronization objects during test cleanup. */
+static int delayed_wait(pthread_cond_t *, pthread_mutex_t *);
+static int joinable_create(pthread_t *, const pthread_attr_t *,
+                           void *(*)(void *), void *);
+#define pthread_cond_wait delayed_wait
+#define pthread_create joinable_create
+#include "../src/net/http/http.c"
+#undef pthread_create
+#undef pthread_cond_wait
+
+#define JOBS 8
+#define MAX_THREADS (JOBS * 4)
+static pthread_mutex_t gate_mu = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t gate_cv = PTHREAD_COND_INITIALIZER;
+static bool initial_parked, release_initial, release_handlers;
+static int started, finished;
+static bool seen[JOBS];
+static pthread_t threads[MAX_THREADS];
+static int thread_count;
+
+static struct timespec deadline(void) {
+    struct timespec ts;
+    assert(clock_gettime(CLOCK_REALTIME, &ts) == 0);
+    ts.tv_sec += 3;
+    return ts;
+}
+
+static int delayed_wait(pthread_cond_t *cond, pthread_mutex_t *mutex) {
+    if (cond == &g_dyn_pool.cond) {
+        pthread_mutex_lock(&gate_mu);
+        if (!initial_parked) {
+            initial_parked = true;
+            pthread_mutex_unlock(mutex);
+            pthread_cond_broadcast(&gate_cv);
+            while (!release_initial) pthread_cond_wait(&gate_cv, &gate_mu);
+            pthread_mutex_unlock(&gate_mu);
+            pthread_mutex_lock(mutex);
+            return 0;
+        }
+        pthread_mutex_unlock(&gate_mu);
+    }
+    return pthread_cond_wait(cond, mutex);
+}
+
+static int joinable_create(pthread_t *thread, const pthread_attr_t *attr,
+                           void *(*start)(void *), void *arg) {
+    pthread_attr_t joinable;
+    assert(pthread_attr_init(&joinable) == 0);
+    size_t stack_size;
+    assert(pthread_attr_getstacksize(attr, &stack_size) == 0);
+    assert(pthread_attr_setstacksize(&joinable, stack_size) == 0);
+    int rc = pthread_create(thread, &joinable, start, arg);
+    pthread_attr_destroy(&joinable);
+    if (!rc) {
+        pthread_mutex_lock(&gate_mu);
+        assert(thread_count < MAX_THREADS);
+        threads[thread_count++] = *thread;
+        pthread_mutex_unlock(&gate_mu);
+    }
+    return rc;
+}
+
+static void held_handler(int fd, void *ctx) {
+    (void)fd;
+    int index = *(int *)ctx;
+    pthread_mutex_lock(&gate_mu);
+    assert(index >= 0 && index < JOBS && !seen[index]);
+    seen[index] = true;
+    started++;
+    pthread_cond_broadcast(&gate_cv);
+    while (!release_handlers) pthread_cond_wait(&gate_cv, &gate_mu);
+    finished++;
+    pthread_cond_broadcast(&gate_cv);
+    pthread_mutex_unlock(&gate_mu);
+}
+
+int main(void) {
+    alarm(15);
+    assert(setenv("CWIST_C1M_MODE", "0", 1) == 0);
+    assert(setenv("CWIST_WORKER_THREADS", "1", 1) == 0);
+    assert(setenv("CWIST_POOL_IDLE_TIMEOUT_MS", "0", 1) == 0);
+    assert(unsetenv("CWIST_POOL_PREWARM") == 0);
+    assert(cwist_http_pool_init() == 0);
+    pthread_mutex_lock(&gate_mu);
+    struct timespec until = deadline();
+    while (!initial_parked) {
+        int rc = pthread_cond_timedwait(&gate_cv, &gate_mu, &until);
+        assert(rc == 0);
+    }
+    pthread_mutex_unlock(&gate_mu);
+
+    int ids[JOBS];
+    for (int i = 0; i < JOBS; i++) {
+        ids[i] = i;
+        /* The handler owns no transport in this queue-only regression. */
+        cwist_http_pool_submit(-1, held_handler, &ids[i]);
+    }
+    pthread_mutex_lock(&gate_mu);
+    release_initial = true;
+    pthread_cond_broadcast(&gate_cv);
+    until = deadline();
+    while (started < JOBS) {
+        int rc = pthread_cond_timedwait(&gate_cv, &gate_mu, &until);
+        if (rc == ETIMEDOUT) break;
+        assert(rc == 0);
+    }
+    int started_without_release = started;
+    /* Release only after observing the contract; otherwise one worker could
+     * run all eight handlers serially and disguise the starvation. */
+    release_handlers = true;
+    pthread_cond_broadcast(&gate_cv);
+    until = deadline();
+    while (finished < JOBS) {
+        int rc = pthread_cond_timedwait(&gate_cv, &gate_mu, &until);
+        assert(rc == 0);
+    }
+    pthread_mutex_unlock(&gate_mu);
+
+    pthread_mutex_lock(&g_dyn_pool.lock);
+    atomic_store(&g_dyn_pool.running, false);
+    pthread_cond_broadcast(&g_dyn_pool.cond);
+    pthread_mutex_unlock(&g_dyn_pool.lock);
+    for (int i = 0; i < thread_count; i++) assert(pthread_join(threads[i], NULL) == 0);
+    assert(atomic_load(&g_http_inflight) == 0);
+    assert(atomic_load(&g_dyn_pool.pending_tasks) == 0);
+    cwist_http_pool_destroy();
+    printf("classic burst: %d/%d handlers started before any completion; workers=%d\n",
+           started_without_release, JOBS, thread_count);
+    if (started_without_release != JOBS) {
+        fputs("FAIL: queued connections starve behind held keep-alive handlers\n", stderr);
+        return 1;
+    }
+    puts("classic burst scaling: PASS");
+    return 0;
+}


### PR DESCRIPTION
## Summary

Related to #25; **additional partial fix, do not close the issue**. This PR is based directly on `dev` and does not include PR #37.

Fix classic-mode pool starvation when a burst arrives before signalled idle workers reacquire the queue mutex. `idle > 0` does not mean the queued work is covered: the available worker can enter a long-lived keep-alive handler while other connections remain queued with no future submission to trigger growth.

- Compare queued demand with idle capacity under the queue mutex.
- Serialize the worker cap check and spawn reservation with that decision.
- Keep existing defaults, one growth attempt per submit, and creation-failure rollback.
- Add deterministic tests for one/multiple delayed idle workers, concurrent submitters at the cap, and two injected creation failures.

## Evidence

The original source starts only **1/8** held handlers before any handler completes; the fix starts **8/8**. All four regression cases pass, including complete queue/inflight draining after release.

Three paired HTTP rounds at c64/c256/c512 (18 corrected-clock, error-free runs) **did not establish a consistent steady-state P99.999 reduction**. All per-run values, including the candidate c64 outlier, are in `docs/classic-pool-starvation.md`.

Initial stock-wrk measurements were discarded because VM wall-clock backsteps can underflow wrk's unsigned timing and appear as timeouts. The retained comparisons use the same monotonic-clock wrk build on both sides. This is a measurement correction, not a server speedup. Independent uncontrolled HTTP bursts completed on both binaries and did not reproduce the controlled race.

## Validation / why draft

- `-Werror` build: PASS.
- Normal full suite: **56/57 targets pass**. `test_grpc.c:243` fails its append assertion. Rebuilding with original `dev` HTTP source reproduces the identical failure in this ARM64 Linux environment; its underlying cause remains unresolved.
- Clean ASan/UBSan build and six HTTP-related targets: PASS (`test_classic_pool_scaling`, `test_http`, `test_http_pipeline`, `test_http_fairness`, `test_async_defer`, `test_conn_registry`). Existing LSan suppressions, leak detection enabled.
- Independent static code/security review: approve, no blocking candidate defect.
- Hosted CI pending. The full suite is **not represented as green**; this stays a draft for additional validation.

No default tuning, allocator replacement, reactor changes, automatic merge, or issue closure.
