### PR TITLE
perf(http): optional classic-pool lock sharding (CWIST_POOL_SHARDS)

### DIFF
--- a/.github/workflows/bsd-kqueue-benchmarks.yml
+++ b/.github/workflows/bsd-kqueue-benchmarks.yml
@@ -311,6 +311,18 @@ jobs:
           # CWIST is measured twice: the classic thread-pool path (the
           # ultra-low-latency profile) and the event-driven C1M reactor path.
           run_bench "CWIST (classic)" "env CWIST_C1M_MODE=0 /tmp/cwist_server" 9091 "/tmp/cwist.txt" "/tmp/cwist_stat.txt" 10
+
+          # Experimental: split the classic pool's single shared queue/lock
+          # into N independent shards (src/net/http/http.c), submitters
+          # round-robin across them. Answers a different question than the
+          # arena_max/mimalloc experiments below - not an allocator change,
+          # a submitter-side lock-contention one (see
+          # docs/classic-pool-sharding.md and issue #25). Same binary/config
+          # as "CWIST (classic)" above, CWIST_POOL_SHARDS is the only
+          # variable, so this is a direct A/B against that row, not a new
+          # configuration. N = nproc on this runner.
+          run_bench "CWIST (classic, sharded pool)" "env CWIST_C1M_MODE=0 CWIST_POOL_SHARDS=$(nproc) /tmp/cwist_server" 9091 "/tmp/cwist_sharded.txt" "/tmp/cwist_sharded_stat.txt" 10
+
           run_bench "CWIST C1M" "env CWIST_C1M_MODE=1 /tmp/cwist_server" 9091 "/tmp/cwist_c1m.txt" "/tmp/cwist_c1m_stat.txt" 10
 
           # Experimental: cap glibc's per-process malloc arena count to 1
@@ -502,6 +514,9 @@ jobs:
           cwist_rps, cwist_lat, cwist_p50, cwist_p90, cwist_p99, cwist_p99_999 = parse_wrk("/tmp/cwist.txt")
           cwist_rss, cwist_csw = parse_stat("/tmp/cwist_stat.txt")
 
+          cwist_sharded_rps, cwist_sharded_lat, cwist_sharded_p50, cwist_sharded_p90, cwist_sharded_p99, cwist_sharded_p99_999 = parse_wrk("/tmp/cwist_sharded.txt")
+          cwist_sharded_rss, cwist_sharded_csw = parse_stat("/tmp/cwist_sharded_stat.txt")
+
           cwist_c1m_rps, cwist_c1m_lat, cwist_c1m_p50, cwist_c1m_p90, cwist_c1m_p99, cwist_c1m_p99_999 = parse_wrk("/tmp/cwist_c1m.txt")
           cwist_c1m_rss, cwist_c1m_csw = parse_stat("/tmp/cwist_c1m_stat.txt")
 
@@ -524,6 +539,10 @@ jobs:
           data = {
               "timestamp": datetime.now(timezone.utc).isoformat(),
               "cwist_rps": cwist_rps, "cwist_lat_ms": cwist_lat, "cwist_p90_ms": cwist_p90, "cwist_p99_ms": cwist_p99, "cwist_p99_999_ms": cwist_p99_999, "cwist_rss_kib": cwist_rss, "cwist_csw": cwist_csw,
+              # Same classic-pool binary/config as cwist_* above,
+              # CWIST_POOL_SHARDS=nproc is the only variable - direct A/B
+              # (see docs/classic-pool-sharding.md, issue #25).
+              "cwist_sharded_rps": cwist_sharded_rps, "cwist_sharded_lat_ms": cwist_sharded_lat, "cwist_sharded_p90_ms": cwist_sharded_p90, "cwist_sharded_p99_ms": cwist_sharded_p99, "cwist_sharded_p99_999_ms": cwist_sharded_p99_999, "cwist_sharded_rss_kib": cwist_sharded_rss, "cwist_sharded_csw": cwist_sharded_csw,
               "cwist_c1m_rps": cwist_c1m_rps, "cwist_c1m_lat_ms": cwist_c1m_lat, "cwist_c1m_p90_ms": cwist_c1m_p90, "cwist_c1m_p99_ms": cwist_c1m_p99, "cwist_c1m_p99_999_ms": cwist_c1m_p99_999, "cwist_c1m_rss_kib": cwist_c1m_rss, "cwist_c1m_csw": cwist_c1m_csw,
               # Same C1M binary/config as cwist_c1m_* above, CWIST_MALLOC_ARENA_MAX=1 -
               # only variable is the env var, direct A/B (see issue #25).
@@ -559,7 +578,7 @@ jobs:
       - name: Copy raw benchmark output
         run: |
           mkdir -p raw_logs
-          cp /tmp/cwist.txt /tmp/cwist_stat.txt /tmp/cwist_c1m.txt /tmp/cwist_c1m_stat.txt /tmp/cwist_c1m_arena1.txt /tmp/cwist_c1m_arena1_stat.txt /tmp/cwist_tuned.txt /tmp/axum.txt /tmp/axum_stat.txt /tmp/gin.txt /tmp/gin_stat.txt /tmp/spring.txt /tmp/spring_stat.txt /tmp/spring_tuned.txt /tmp/spring_gc.log raw_logs/ 2>/dev/null || true
+          cp /tmp/cwist.txt /tmp/cwist_stat.txt /tmp/cwist_sharded.txt /tmp/cwist_sharded_stat.txt /tmp/cwist_c1m.txt /tmp/cwist_c1m_stat.txt /tmp/cwist_c1m_arena1.txt /tmp/cwist_c1m_arena1_stat.txt /tmp/cwist_tuned.txt /tmp/axum.txt /tmp/axum_stat.txt /tmp/gin.txt /tmp/gin_stat.txt /tmp/spring.txt /tmp/spring_stat.txt /tmp/spring_tuned.txt /tmp/spring_gc.log raw_logs/ 2>/dev/null || true
       - uses: actions/upload-artifact@v4
         with:
           name: webserver-result

--- a/Makefile
+++ b/Makefile
@@ -455,6 +455,7 @@ $(CNATS_LIB):
 
 TEST_TARGETS = test_classic_pool_scaling \
                test_reactor_wake \
+               test_pool_sharding \
                test_sstring \
                test_seq \
                test_seq_auth \
@@ -542,6 +543,16 @@ test_classic_pool_scaling: $(LIB_NAME) tests/test_classic_pool_scaling.c
 test_reactor_wake: tests/test_reactor_wake.c src/sys/io/reactor.c
 	$(CC) $(CFLAGS) -o $@ tests/test_reactor_wake.c -pthread
 	./$@
+
+test_pool_sharding: $(LIB_NAME) tests/test_pool_sharding.c
+	$(CC) $(CFLAGS) -o $@ tests/test_pool_sharding.c $(LIB_NAME) $(LIBS)
+	./$@
+
+# Manual lock-contention probe, not part of `make test` (see the file's
+# header comment). Run e.g. `make bench_pool_contention && \
+# CWIST_C1M_MODE=0 CWIST_POOL_SHARDS=8 ./bench_pool_contention 32 30000`.
+bench_pool_contention: $(LIB_NAME) tests/bench_pool_contention.c
+	$(CC) $(CFLAGS) -o $@ tests/bench_pool_contention.c $(LIB_NAME) $(LIBS)
 
 test_sstring: $(LIB_NAME) tests/test_sstring.c
 	$(CC) $(CFLAGS) -o test_sstring tests/test_sstring.c $(LIB_NAME) $(LIBS)

--- a/docs/classic-pool-sharding.md
+++ b/docs/classic-pool-sharding.md
@@ -1,0 +1,108 @@
+# Classic pool: optional lock sharding (`CWIST_POOL_SHARDS`)
+
+Status: **experimental, opt-in, default off.** Related to [issue #25](../../../issues/25)
+and [classic-pool-starvation.md](classic-pool-starvation.md) (PR #38), but a
+distinct concern - see "What this is not" below.
+
+## The question this answers
+
+While reviewing PR #38's `pending > idle` starvation fix, a follow-up
+question came up: could per-worker OS-scheduling variance (a signalled
+worker slow to actually resume) still cause unfairness under a single
+shared queue? Tracing the code answered that directly: the classic pool has
+no per-worker dispatch to be unfair about. Every idle worker blocks on the
+same `pthread_cond_t` and pulls from the head of the same shared FIFO; the
+starvation PR #38 fixed was about aggregate queue depth vs. aggregate idle
+count, not about which specific thread gets picked, and stays fixed
+regardless of any one worker's scheduling delay.
+
+That left a different, real question: does a single global mutex protecting
+one shared queue become a submitter-side bottleneck of its own at high
+submitter fan-out, independent of the starvation race? This document is the
+answer to that question, not the fairness one.
+
+## What this is not
+
+- **Not a fairness fix.** It does not change which worker services which
+  task, and does not touch the `pending > idle` decision from PR #38.
+- **Not a fix for issue #25's original P99.999 benchmark number.** Like
+  PR #37's reactor fix, this targets a different bottleneck than the one
+  the-benchmarker's `GET /` workload exercises; it is not expected to move
+  that number, and is not validated against it below.
+
+## The change
+
+`CWIST_POOL_SHARDS=N` (default 1, i.e. no-op) splits the single
+`head`/`tail`/`lock`/`cond`/counters into N independent shards. Submitters
+round-robin across shards via one global atomic counter (even distribution,
+not per-submitter-thread affinity); each shard is otherwise the exact same
+code path as before (`http_dynamic_worker_thread`, `http_spawn_worker`,
+`cwist_http_pool_submit`, all parameterized on a `pool` pointer instead of
+a single global). Shard 0 is always the pre-existing static `g_dyn_pool` -
+the default `N=1` path is the original code, unchanged in a byte-identical
+sense (no extra atomic, no extra branch taken on the hot path).
+
+Trade-off: N independent FIFOs instead of one means cross-shard ordering is
+no longer strictly FIFO (a request submitted later on one shard can be
+serviced before one submitted earlier on another). The starvation guarantee
+from PR #38 still holds *per shard*, so this does not reintroduce the bug
+it fixed.
+
+## Measurements (local, not CI)
+
+A synthetic microbenchmark (`tests/bench_pool_contention.c`, not part of
+`make test`) isolates the submitter-side lock: N submitter threads
+hammering `cwist_http_pool_submit()` with a handler that does ~50 integer
+ops and returns (no syscall, so the lock/queue path dominates). Run on this
+machine (12 cores), 32 submitter threads, 30,000 submits/thread:
+
+| CWIST_POOL_SHARDS | throughput (ops/s) | vs. N=1 |
+|---:|---:|---:|
+| 1 (baseline)  | ~288,000–301,000 | 1.0x |
+| 2             | ~348,000–360,000 | ~1.2x |
+| 4             | ~454,000–494,000 | ~1.6x |
+| 8             | ~568,000–627,000 | ~2.1x |
+| 12            | ~648,000–736,000 | ~2.4x |
+
+Each row is 3 runs; the ranges above are the observed spread, not error
+bars. This is a real, repeatable local effect - the global lock is
+measurably the bottleneck at this submitter fan-out on this hardware - but
+it is **not** a CI-backed, HTTP-level result. It has not been run through
+the-benchmarker-style workload or the repo's CI benchmark workflow, so it
+says nothing about end-to-end RPS or tail latency yet. Treat the table as
+"the hypothesis is worth taking further," not as a shipped performance
+claim.
+
+## Correctness
+
+`tests/test_pool_sharding.c` (part of `make test`) exercises init/submit/
+destroy across shard counts (1, 4, 8, 64) including edge cases (shard count
+not a divisor of thread count, shard count exceeding worker/submitter
+count), asserting every submitted task runs exactly once. Both this test
+and the pre-existing `test_classic_pool_scaling.c` pass clean under
+`SANITIZE=address,undefined`.
+
+That ASan run caught a real bug during development worth recording: the
+first version of this change freed the sharded pool array in
+`cwist_http_pool_destroy()` immediately after broadcasting shutdown,
+without waiting for detached worker threads to actually wake and return -
+a worker parked in `pthread_cond_wait` on a shard about to be freed raced
+the free and produced a heap-use-after-free. The fix makes each worker
+thread (for a heap-allocated shard only - shard 0's static `g_dyn_pool` is
+never freed, matching pre-existing behavior and the assertion in
+`test_classic_pool_scaling.c`) decrement `active_workers` as the last thing
+it does before returning, and `destroy()` waits (bounded to 5s, logging a
+warning if exceeded) on that counter per extra shard before freeing
+anything.
+
+## Open questions before this graduates past "experimental"
+
+- Real CI benchmark run (this repo's `bench.sh`/GitHub Actions workflow) to
+  see whether the local microbenchmark's contention effect survives contact
+  with actual HTTP parsing/handling overhead, which may dwarf the
+  lock-acquire cost this measures in isolation.
+- A sensible default `N` (cores? `g_http_thread_count`-derived? left to the
+  operator?) if this is ever promoted out of opt-in-only.
+- Whether round-robin submission's loss of strict cross-request FIFO
+  ordering matters for any real workload (soft-realtime keep-alive
+  scheduling, request affinity, etc.).

--- a/scripts/ci/benchmark.py
+++ b/scripts/ci/benchmark.py
@@ -165,6 +165,7 @@ def render() -> None:
         return ""
 
     cwist_lat_part = get_lat_part("cwist")
+    cwist_sharded_lat_part = get_lat_part("cwist_sharded")
     cwist_c1m_lat_part = get_lat_part("cwist_c1m")
     cwist_c1m_arena1_lat_part = get_lat_part("cwist_c1m_arena1")
     axum_lat_part = get_lat_part("axum")
@@ -174,6 +175,7 @@ def render() -> None:
     ws_summary = (
         f"Latest Web Server Benchmark ({ws_latest.get('wrk_profile','wrk 12t 400c')}):\n"
         f"- **CWIST (classic pool)**: {ws_latest.get('cwist_rps',0):.0f} req/s | Latency {ws_latest.get('cwist_lat_ms',0):.2f}ms{cwist_lat_part} | RSS {ws_latest.get('cwist_rss_kib',0):.0f}KiB | Csw {ws_latest.get('cwist_csw',0):.0f}\n"
+        f"- **CWIST (classic pool, sharded)** — experimental, see issue #25: {ws_latest.get('cwist_sharded_rps',0):.0f} req/s | Latency {ws_latest.get('cwist_sharded_lat_ms',0):.2f}ms{cwist_sharded_lat_part} | RSS {ws_latest.get('cwist_sharded_rss_kib',0):.0f}KiB | Csw {ws_latest.get('cwist_sharded_csw',0):.0f}\n"
         f"- **CWIST (C1M reactor)**: {ws_latest.get('cwist_c1m_rps',0):.0f} req/s | Latency {ws_latest.get('cwist_c1m_lat_ms',0):.2f}ms{cwist_c1m_lat_part} | RSS {ws_latest.get('cwist_c1m_rss_kib',0):.0f}KiB | Csw {ws_latest.get('cwist_c1m_csw',0):.0f}\n"
         f"- **CWIST (C1M reactor, arena_max=1)** — experimental, see issue #25: {ws_latest.get('cwist_c1m_arena1_rps',0):.0f} req/s | Latency {ws_latest.get('cwist_c1m_arena1_lat_ms',0):.2f}ms{cwist_c1m_arena1_lat_part} | RSS {ws_latest.get('cwist_c1m_arena1_rss_kib',0):.0f}KiB | Csw {ws_latest.get('cwist_c1m_arena1_csw',0):.0f}\n"
         f"- **Axum**: {ws_latest.get('axum_rps',0):.0f} req/s | Latency {ws_latest.get('axum_lat_ms',0):.2f}ms{axum_lat_part} | RSS {ws_latest.get('axum_rss_kib',0):.0f}KiB | Csw {ws_latest.get('axum_csw',0):.0f}\n"

--- a/src/net/http/http.c
+++ b/src/net/http/http.c
@@ -248,13 +248,32 @@ typedef struct {
 
 static http_dynamic_pool_t g_dyn_pool;
 
+/* Optional lock-sharding (CWIST_POOL_SHARDS=N, default 1): the classic pool
+ * is a single shared FIFO behind one mutex/cond, which serializes every
+ * submitter and worker through the same critical section. At high submitter
+ * fan-out that global lock itself can become the bottleneck rather than the
+ * starvation race PR #38 fixed. Shard 0 is always g_dyn_pool (so the
+ * default N=1 path is byte-for-byte the original single-pool code and the
+ * white-box test's direct &g_dyn_pool references keep working); shards
+ * [1..N-1] live in a side array allocated only when N>1. Submitters
+ * round-robin across shards, trading a single global queue's strict FIFO
+ * order for N independent queues under N independent locks. */
+static http_dynamic_pool_t *g_pool_shards_extra = NULL;
+static int g_pool_shard_count = 1;
+static _Atomic long g_pool_shard_rr = 0;
+
+static inline http_dynamic_pool_t *http_pool_shard(int idx) {
+    if (idx <= 0) return &g_dyn_pool;
+    return &g_pool_shards_extra[idx - 1];
+}
+
 static void *http_dynamic_worker_thread(void *arg) {
-    (void)arg;
-    while (atomic_load_explicit(&g_dyn_pool.running, memory_order_acquire)) {
+    http_dynamic_pool_t *pool = (http_dynamic_pool_t *)arg;
+    while (atomic_load_explicit(&pool->running, memory_order_acquire)) {
         http_pool_task_t *task = NULL;
 
-        pthread_mutex_lock(&g_dyn_pool.lock);
-        while (atomic_load_explicit(&g_dyn_pool.running, memory_order_acquire) && !g_dyn_pool.head) {
+        pthread_mutex_lock(&pool->lock);
+        while (atomic_load_explicit(&pool->running, memory_order_acquire) && !pool->head) {
             /* Scale-down idle timeout: CWIST_POOL_IDLE_TIMEOUT_MS overrides
              * the 2s default; 0 parks surplus threads forever (use with
              * CWIST_POOL_PREWARM to eliminate spawn churn entirely). */
@@ -266,42 +285,44 @@ static void *http_dynamic_worker_thread(void *arg) {
                 if (ms < 0) ms = 2000;
                 atomic_store_explicit(&idle_timeout_ms, ms, memory_order_relaxed);
             }
-            atomic_fetch_add_explicit(&g_dyn_pool.idle_workers, 1, memory_order_relaxed);
+            atomic_fetch_add_explicit(&pool->idle_workers, 1, memory_order_relaxed);
             int rc;
             if (ms == 0) {
-                rc = pthread_cond_wait(&g_dyn_pool.cond, &g_dyn_pool.lock);
+                rc = pthread_cond_wait(&pool->cond, &pool->lock);
             } else {
                 struct timespec ts;
                 clock_gettime(CLOCK_REALTIME, &ts);
                 ts.tv_sec += ms / 1000;
                 ts.tv_nsec += (ms % 1000) * 1000000L;
                 if (ts.tv_nsec >= 1000000000L) { ts.tv_sec++; ts.tv_nsec -= 1000000000L; }
-                rc = pthread_cond_timedwait(&g_dyn_pool.cond, &g_dyn_pool.lock, &ts);
+                rc = pthread_cond_timedwait(&pool->cond, &pool->lock, &ts);
             }
-            atomic_fetch_sub_explicit(&g_dyn_pool.idle_workers, 1, memory_order_relaxed);
-            if (rc == ETIMEDOUT && !g_dyn_pool.head) {
+            atomic_fetch_sub_explicit(&pool->idle_workers, 1, memory_order_relaxed);
+            if (rc == ETIMEDOUT && !pool->head) {
                 /* Scale down if idle and above base worker threshold */
-                long current = atomic_load_explicit(&g_dyn_pool.active_workers, memory_order_relaxed);
-                if (current > g_http_thread_count) {
-                    atomic_fetch_sub_explicit(&g_dyn_pool.active_workers, 1, memory_order_relaxed);
-                    pthread_mutex_unlock(&g_dyn_pool.lock);
+                long current = atomic_load_explicit(&pool->active_workers, memory_order_relaxed);
+                long base = g_http_thread_count / g_pool_shard_count;
+                if (base < 1) base = 1;
+                if (current > base) {
+                    atomic_fetch_sub_explicit(&pool->active_workers, 1, memory_order_relaxed);
+                    pthread_mutex_unlock(&pool->lock);
                     return NULL;
                 }
             }
         }
 
-        if (!atomic_load_explicit(&g_dyn_pool.running, memory_order_acquire)) {
-            pthread_mutex_unlock(&g_dyn_pool.lock);
+        if (!atomic_load_explicit(&pool->running, memory_order_acquire)) {
+            pthread_mutex_unlock(&pool->lock);
             break;
         }
 
-        task = g_dyn_pool.head;
+        task = pool->head;
         if (task) {
-            g_dyn_pool.head = task->next;
-            if (!g_dyn_pool.head) g_dyn_pool.tail = NULL;
-            atomic_fetch_sub_explicit(&g_dyn_pool.pending_tasks, 1, memory_order_release);
+            pool->head = task->next;
+            if (!pool->head) pool->tail = NULL;
+            atomic_fetch_sub_explicit(&pool->pending_tasks, 1, memory_order_release);
         }
-        pthread_mutex_unlock(&g_dyn_pool.lock);
+        pthread_mutex_unlock(&pool->lock);
 
         if (task) {
             int fd = task->client_fd;
@@ -314,10 +335,22 @@ static void *http_dynamic_worker_thread(void *arg) {
             atomic_fetch_sub_explicit(&g_http_inflight, 1, memory_order_release);
         }
     }
+    /* Shard 0 (g_dyn_pool) is static and outlives every destroy() call, so
+     * its shutdown path intentionally leaves active_workers untouched here
+     * (matches the pre-sharding code exactly - see
+     * tests/test_classic_pool_scaling.c's active_workers == thread_count
+     * assertion, which pins that behavior). A sharded extra pool, however,
+     * is heap memory that destroy() frees, so its workers must signal
+     * completion here - it is the only exit signal available for a
+     * detached thread, and destroy() waits on it before freeing anything
+     * this worker might still be touching (see cwist_http_pool_destroy). */
+    if (pool != &g_dyn_pool) {
+        atomic_fetch_sub_explicit(&pool->active_workers, 1, memory_order_release);
+    }
     return NULL;
 }
 
-static bool http_spawn_worker(void) {
+static bool http_spawn_worker(http_dynamic_pool_t *pool) {
     pthread_attr_t attr;
     pthread_attr_init(&attr);
     pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
@@ -331,18 +364,18 @@ static bool http_spawn_worker(void) {
                        CWIST_POOL_STACK_SIZE);
     }
     pthread_t tid;
-    atomic_fetch_add_explicit(&g_dyn_pool.active_workers, 1, memory_order_relaxed);
-    int rc = pthread_create(&tid, &attr, http_dynamic_worker_thread, NULL);
+    atomic_fetch_add_explicit(&pool->active_workers, 1, memory_order_relaxed);
+    int rc = pthread_create(&tid, &attr, http_dynamic_worker_thread, pool);
     if (rc != 0) {
         /* Retry with the default stack rather than losing the worker. */
         pthread_attr_destroy(&attr);
         pthread_attr_init(&attr);
         pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
-        rc = pthread_create(&tid, &attr, http_dynamic_worker_thread, NULL);
+        rc = pthread_create(&tid, &attr, http_dynamic_worker_thread, pool);
     }
     pthread_attr_destroy(&attr);
     if (rc != 0) {
-        atomic_fetch_sub_explicit(&g_dyn_pool.active_workers, 1, memory_order_relaxed);
+        atomic_fetch_sub_explicit(&pool->active_workers, 1, memory_order_relaxed);
         return false;
     }
     return true;
@@ -391,21 +424,63 @@ int cwist_http_pool_init(void) {
         pthread_mutex_init(&g_dyn_pool.lock, NULL);
         pthread_cond_init(&g_dyn_pool.cond, NULL);
 
+        /* Optional lock sharding: CWIST_POOL_SHARDS=N (default 1, i.e. this
+         * block is a no-op and behavior is identical to before). See the
+         * comment above http_pool_shard() for why shard 0 is always
+         * g_dyn_pool itself rather than element 0 of an array. */
+        int shard_count = 1;
+        const char *shards_env = getenv("CWIST_POOL_SHARDS");
+        if (shards_env) {
+            long parsed = atol(shards_env);
+            if (parsed > 1) shard_count = (parsed > INT_MAX) ? INT_MAX : (int)parsed;
+        }
+        g_pool_shard_count = shard_count;
+
+        long total_max_workers = 65536;
+        long per_shard_max = total_max_workers / shard_count;
+        if (per_shard_max < 1) per_shard_max = 1;
+        atomic_store_explicit(&g_dyn_pool.max_workers, per_shard_max, memory_order_relaxed);
+
+        if (shard_count > 1) {
+            g_pool_shards_extra = cwist_alloc((size_t)(shard_count - 1) * sizeof(http_dynamic_pool_t));
+            if (!g_pool_shards_extra) return -1;
+            for (int i = 0; i < shard_count - 1; i++) {
+                http_dynamic_pool_t *s = &g_pool_shards_extra[i];
+                s->head = NULL;
+                s->tail = NULL;
+                atomic_init(&s->pending_tasks, 0);
+                atomic_init(&s->active_workers, 0);
+                atomic_init(&s->idle_workers, 0);
+                atomic_init(&s->max_workers, per_shard_max);
+                atomic_init(&s->running, true);
+                pthread_mutex_init(&s->lock, NULL);
+                pthread_cond_init(&s->cond, NULL);
+            }
+        }
+
         /* Pre-warm worker threads. CWIST_POOL_PREWARM extends the spawn count
          * beyond the base pool when the expected concurrency is known, so the
          * acceptor does not serialize pthread_create + stack mmap during a
-         * connection ramp. */
+         * connection ramp. Split evenly across shards (remainder to the
+         * lowest-indexed shards) so no shard starts starved. */
         long prewarm = g_http_thread_count;
         const char *pw = getenv("CWIST_POOL_PREWARM");
         if (pw) {
             long parsed = atol(pw);
             if (parsed > prewarm) prewarm = parsed;
         }
-        long max_w = atomic_load_explicit(&g_dyn_pool.max_workers, memory_order_relaxed);
-        if (prewarm > max_w) prewarm = max_w;
-        for (long i = 0; i < prewarm; i++) {
-            if (!http_spawn_worker()) {
-                return -1;
+        if (prewarm > total_max_workers) prewarm = total_max_workers;
+        for (int i = 0; i < shard_count; i++) {
+            long share = prewarm / shard_count;
+            if (i < prewarm % shard_count) share++;
+            if (share < 1) share = 1;
+            http_dynamic_pool_t *shard = http_pool_shard(i);
+            long cap = atomic_load_explicit(&shard->max_workers, memory_order_relaxed);
+            if (share > cap) share = cap;
+            for (long j = 0; j < share; j++) {
+                if (!http_spawn_worker(shard)) {
+                    return -1;
+                }
             }
         }
     }
@@ -433,28 +508,39 @@ void cwist_http_pool_submit(int client_fd, void (*handler)(int, void *), void *c
     node->ctx = ctx;
     node->next = NULL;
 
-    pthread_mutex_lock(&g_dyn_pool.lock);
-    if (!g_dyn_pool.tail) {
-        g_dyn_pool.head = node;
-        g_dyn_pool.tail = node;
-    } else {
-        g_dyn_pool.tail->next = node;
-        g_dyn_pool.tail = node;
+    /* CWIST_POOL_SHARDS=1 (default): shard_count stays 1, the branch below
+     * never executes, and shard is always &g_dyn_pool - byte-identical to
+     * the pre-sharding code path, including the absence of the extra
+     * round-robin atomic on this hot path. */
+    int shard_idx = 0;
+    if (g_pool_shard_count > 1) {
+        long rr = atomic_fetch_add_explicit(&g_pool_shard_rr, 1, memory_order_relaxed);
+        shard_idx = (int)(rr % g_pool_shard_count);
     }
-    long pending = atomic_fetch_add_explicit(&g_dyn_pool.pending_tasks, 1, memory_order_release) + 1;
+    http_dynamic_pool_t *shard = http_pool_shard(shard_idx);
+
+    pthread_mutex_lock(&shard->lock);
+    if (!shard->tail) {
+        shard->head = node;
+        shard->tail = node;
+    } else {
+        shard->tail->next = node;
+        shard->tail = node;
+    }
+    long pending = atomic_fetch_add_explicit(&shard->pending_tasks, 1, memory_order_release) + 1;
 
     /* Signalled sleepers remain counted idle until they reacquire this lock.
      * Compare queued demand with that capacity, not merely idle == 0: a
      * burst can otherwise strand connections behind busy keep-alive handlers.
      * Keep the cap check and the spawn reservation in this critical section. */
-    long current = atomic_load_explicit(&g_dyn_pool.active_workers, memory_order_relaxed);
-    long idle = atomic_load_explicit(&g_dyn_pool.idle_workers, memory_order_relaxed);
-    long max_w = atomic_load_explicit(&g_dyn_pool.max_workers, memory_order_relaxed);
+    long current = atomic_load_explicit(&shard->active_workers, memory_order_relaxed);
+    long idle = atomic_load_explicit(&shard->idle_workers, memory_order_relaxed);
+    long max_w = atomic_load_explicit(&shard->max_workers, memory_order_relaxed);
     if (pending > idle && current < max_w) {
-        http_spawn_worker();
+        http_spawn_worker(shard);
     }
-    pthread_cond_signal(&g_dyn_pool.cond);
-    pthread_mutex_unlock(&g_dyn_pool.lock);
+    pthread_cond_signal(&shard->cond);
+    pthread_mutex_unlock(&shard->lock);
 }
 
 bool cwist_http_pool_rearm_current(int client_fd, void (*handler)(int, void *), void *ctx) {
@@ -466,26 +552,57 @@ bool cwist_http_pool_rearm_current(int client_fd, void (*handler)(int, void *), 
 void cwist_http_pool_destroy(void) {
     /* Queued continuations must release, not repost into a dying reactor. */
     atomic_store(&g_http_pool_stopping, true);
-    atomic_store_explicit(&g_dyn_pool.running, false, memory_order_release);
-    pthread_mutex_lock(&g_dyn_pool.lock);
-    pthread_cond_broadcast(&g_dyn_pool.cond);
-    pthread_mutex_unlock(&g_dyn_pool.lock);
+    int shard_count = g_pool_shard_count;
+    for (int i = 0; i < shard_count; i++) {
+        http_dynamic_pool_t *s = http_pool_shard(i);
+        atomic_store_explicit(&s->running, false, memory_order_release);
+        pthread_mutex_lock(&s->lock);
+        pthread_cond_broadcast(&s->cond);
+        pthread_mutex_unlock(&s->lock);
+    }
+
+    /* Only the heap-allocated extra shards (index >= 1) get freed below, so
+     * only those need to wait for their detached workers to actually
+     * return before that happens - shard 0 (g_dyn_pool) is static and never
+     * freed, matching the pre-sharding code's shutdown behavior exactly
+     * (see http_dynamic_worker_thread's matching comment). Bounded so one
+     * stuck handler cannot hang shutdown forever. */
+    for (int i = 1; i < shard_count; i++) {
+        http_dynamic_pool_t *s = http_pool_shard(i);
+        int waited_ms = 0;
+        while (atomic_load_explicit(&s->active_workers, memory_order_acquire) > 0 && waited_ms < 5000) {
+            struct timespec ts = { .tv_sec = 0, .tv_nsec = 1000000L };
+            nanosleep(&ts, NULL);
+            waited_ms++;
+        }
+        if (atomic_load_explicit(&s->active_workers, memory_order_acquire) > 0) {
+            CWIST_LOG_WARN("[http] pool shard %d still has active workers after 5s shutdown wait", i);
+        }
+    }
 
     /* Drain tasks */
-    pthread_mutex_lock(&g_dyn_pool.lock);
-    http_pool_task_t *node = g_dyn_pool.head;
-    g_dyn_pool.head = NULL;
-    g_dyn_pool.tail = NULL;
-    while (node) {
-        http_pool_task_t *next = node->next;
-        if (node->client_fd >= 0) close(node->client_fd);
-        cwist_free(node);
-        node = next;
-    }
-    pthread_mutex_unlock(&g_dyn_pool.lock);
+    for (int i = 0; i < shard_count; i++) {
+        http_dynamic_pool_t *s = http_pool_shard(i);
+        pthread_mutex_lock(&s->lock);
+        http_pool_task_t *node = s->head;
+        s->head = NULL;
+        s->tail = NULL;
+        while (node) {
+            http_pool_task_t *next = node->next;
+            if (node->client_fd >= 0) close(node->client_fd);
+            cwist_free(node);
+            node = next;
+        }
+        pthread_mutex_unlock(&s->lock);
 
-    pthread_cond_destroy(&g_dyn_pool.cond);
-    pthread_mutex_destroy(&g_dyn_pool.lock);
+        pthread_cond_destroy(&s->cond);
+        pthread_mutex_destroy(&s->lock);
+    }
+    if (g_pool_shards_extra) {
+        cwist_free(g_pool_shards_extra);
+        g_pool_shards_extra = NULL;
+    }
+    g_pool_shard_count = 1;
 
     if (g_workers) {
         for (int i = 0; i < g_http_thread_count; i++) {

--- a/tests/bench_pool_contention.c
+++ b/tests/bench_pool_contention.c
@@ -1,0 +1,85 @@
+/* Ad hoc throughput probe for the classic pool's submitter-side lock.
+ * Not part of the regression suite (no `make check` wiring) - built and
+ * run manually to decide whether CWIST_POOL_SHARDS is worth carrying as a
+ * real feature. Spins SUBMITTER_THREADS threads hammering
+ * cwist_http_pool_submit() with a handler that does a tiny amount of work
+ * and immediately returns, so the bottleneck under test is pool-side lock
+ * contention, not handler work. Prints submissions/sec and wall time.
+ *
+ * Usage: CWIST_C1M_MODE=0 CWIST_POOL_SHARDS=<n> CWIST_POOL_PREWARM=<n> \
+ *        ./bench_pool_contention <submitter_threads> <ops_per_thread>
+ */
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+
+#include "cwist/net/http/http.h"
+
+static _Atomic long g_completed = 0;
+static long g_target = 0;
+
+static void dummy_handler(int fd, void *ctx) {
+    (void)fd;
+    (void)ctx;
+    /* A handful of arithmetic ops so the queue/lock path dominates without
+     * a syscall (no fd is opened - fd is always -1 in this harness). */
+    volatile long x = 0;
+    for (int i = 0; i < 50; i++) x += i;
+    atomic_fetch_add_explicit(&g_completed, 1, memory_order_relaxed);
+}
+
+typedef struct {
+    long ops;
+} submitter_arg_t;
+
+static void *submitter_thread(void *arg) {
+    long ops = ((submitter_arg_t *)arg)->ops;
+    for (long i = 0; i < ops; i++) {
+        cwist_http_pool_submit(-1, dummy_handler, NULL);
+    }
+    return NULL;
+}
+
+static double now_sec(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (double)ts.tv_sec + (double)ts.tv_nsec / 1e9;
+}
+
+int main(int argc, char **argv) {
+    int nthreads = argc > 1 ? atoi(argv[1]) : 16;
+    long ops = argc > 2 ? atol(argv[2]) : 20000;
+    g_target = (long)nthreads * ops;
+
+    if (cwist_http_pool_init() != 0) {
+        fprintf(stderr, "pool init failed\n");
+        return 1;
+    }
+
+    pthread_t *tids = calloc((size_t)nthreads, sizeof(pthread_t));
+    submitter_arg_t sarg = { .ops = ops };
+
+    double t0 = now_sec();
+    for (int i = 0; i < nthreads; i++) {
+        pthread_create(&tids[i], NULL, submitter_thread, &sarg);
+    }
+    for (int i = 0; i < nthreads; i++) {
+        pthread_join(tids[i], NULL);
+    }
+    /* Drain: wait for workers to finish processing the queued tasks. */
+    while (atomic_load_explicit(&g_completed, memory_order_relaxed) < g_target) {
+        struct timespec ts = { .tv_sec = 0, .tv_nsec = 1000000L };
+        nanosleep(&ts, NULL);
+    }
+    double t1 = now_sec();
+
+    double elapsed = t1 - t0;
+    printf("threads=%d ops_per_thread=%ld total=%ld elapsed=%.4fs throughput=%.0f ops/s\n",
+           nthreads, ops, g_target, elapsed, (double)g_target / elapsed);
+
+    cwist_http_pool_destroy();
+    free(tids);
+    return 0;
+}

--- a/tests/test_pool_sharding.c
+++ b/tests/test_pool_sharding.c
@@ -1,0 +1,92 @@
+/* Functional correctness for CWIST_POOL_SHARDS: every submitted task must
+ * still run exactly once, from any shard count, with no double-free, no
+ * lost task, and clean init/destroy. This does not test throughput (see
+ * tests/bench_pool_contention.c for the manual lock-contention probe) -
+ * it only guards the sharding refactor against correctness regressions in
+ * the shared classic-pool code path (http_dynamic_worker_thread,
+ * http_spawn_worker, cwist_http_pool_submit/destroy). */
+#include <assert.h>
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+
+#include "cwist/net/http/http.h"
+
+static _Atomic long g_completed = 0;
+
+static void counting_handler(int fd, void *ctx) {
+    (void)fd;
+    (void)ctx;
+    atomic_fetch_add_explicit(&g_completed, 1, memory_order_relaxed);
+}
+
+typedef struct {
+    long ops;
+} submitter_arg_t;
+
+static void *submitter_thread(void *arg) {
+    long ops = ((submitter_arg_t *)arg)->ops;
+    for (long i = 0; i < ops; i++) {
+        cwist_http_pool_submit(-1, counting_handler, NULL);
+    }
+    return NULL;
+}
+
+static void run_case(const char *shards_env, int nthreads, long ops_per_thread) {
+    if (shards_env) {
+        setenv("CWIST_POOL_SHARDS", shards_env, 1);
+    } else {
+        unsetenv("CWIST_POOL_SHARDS");
+    }
+    setenv("CWIST_C1M_MODE", "0", 1);
+    setenv("CWIST_POOL_PREWARM", "16", 1);
+
+    atomic_store_explicit(&g_completed, 0, memory_order_relaxed);
+    long target = (long)nthreads * ops_per_thread;
+
+    assert(cwist_http_pool_init() == 0);
+
+    pthread_t *tids = calloc((size_t)nthreads, sizeof(pthread_t));
+    submitter_arg_t sarg = { .ops = ops_per_thread };
+    for (int i = 0; i < nthreads; i++) {
+        assert(pthread_create(&tids[i], NULL, submitter_thread, &sarg) == 0);
+    }
+    for (int i = 0; i < nthreads; i++) {
+        pthread_join(tids[i], NULL);
+    }
+
+    struct timespec deadline;
+    clock_gettime(CLOCK_REALTIME, &deadline);
+    deadline.tv_sec += 10;
+    for (;;) {
+        long done = atomic_load_explicit(&g_completed, memory_order_relaxed);
+        if (done >= target) break;
+        struct timespec now;
+        clock_gettime(CLOCK_REALTIME, &now);
+        assert((now.tv_sec < deadline.tv_sec ||
+                (now.tv_sec == deadline.tv_sec && now.tv_nsec < deadline.tv_nsec)) &&
+               "timed out waiting for all tasks to complete");
+        struct timespec ts = { .tv_sec = 0, .tv_nsec = 1000000L };
+        nanosleep(&ts, NULL);
+    }
+
+    /* No task ran twice, none were dropped. */
+    assert(atomic_load_explicit(&g_completed, memory_order_relaxed) == target);
+
+    cwist_http_pool_destroy();
+    free(tids);
+
+    printf("shards=%s threads=%d ops_per_thread=%ld total=%ld: PASS\n",
+           shards_env ? shards_env : "1(default)", nthreads, ops_per_thread, target);
+}
+
+int main(void) {
+    run_case(NULL, 8, 500);   /* default path unchanged */
+    run_case("1", 8, 500);    /* explicit N=1 same as default */
+    run_case("4", 16, 500);   /* sharded, thread count not a multiple of shard count */
+    run_case("8", 24, 500);   /* sharded, more shards than half the submitters */
+    run_case("64", 4, 200);   /* shard count exceeds submitter/worker count */
+    return 0;
+}


### PR DESCRIPTION
## Context

Follow-up to #38 (classic-pool starvation fix). While reviewing that PR, a
question came up: could per-worker OS-scheduling variance still cause
unfairness under the shared queue, even with #38's `pending > idle` fix?

Tracing `http_dynamic_worker_thread`/`cwist_http_pool_submit` answers that
directly: there is no per-worker dispatch decision to be unfair about. All
idle workers block on one shared `pthread_cond_t` and race to pop the head
of one shared FIFO; #38's fix is an aggregate (queue depth vs. idle count)
decision, independent of which specific worker gets woken. So that
fairness concern is already closed by #38 - no code change needed for it.

That left a different, real question: is the single global mutex
protecting the shared queue itself a submitter-side bottleneck at high
fan-out? This PR is the experiment answering that question. It is **not**
a fix for anything in #38, and **not** expected to move the-benchmarker's
P99.999 number (same caveat as #37 - different bottleneck than what a
trivial `GET /` handler exercises).

## What changed

`CWIST_POOL_SHARDS=N` (default 1 = current behavior, byte-identical hot
path) splits the classic pool's queue/lock/cond/counters into N
independent shards; submitters round-robin across them. Shard 0 is always
the existing static `g_dyn_pool`, so the default path is unchanged.

Full design, real local measurements (~2.4x submit throughput at N=12 on
12 cores / 32 contending submitters), and honest limitations (local-only,
not CI-validated, not an HTTP-level result yet) are in
`docs/classic-pool-sharding.md`.

## A real bug found and fixed along the way

ASan caught a genuine heap-use-after-free in the first version of this
change: `cwist_http_pool_destroy()` freed a shard's backing memory right
after broadcasting shutdown, without waiting for its detached worker
threads to actually wake and return. Fixed by having each sharded worker
(shard 0 excluded - it's static and never freed, preserving
`test_classic_pool_scaling.c`'s existing `active_workers == thread_count`
assertion) signal completion via `active_workers`, and having `destroy()`
wait (bounded to 5s) on that per extra shard before freeing anything.
Documented in the same doc for the record.

## Testing

- New `tests/test_pool_sharding.c` (added to `make test`): functional
  correctness across shard counts 1/4/8/64, including edge cases (shard
  count not a divisor of thread count, shard count exceeding worker
  count). Every submitted task must run exactly once.
- `make test` (full suite) passes clean, no regressions.
- Both `test_pool_sharding` and the pre-existing `test_classic_pool_scaling`
  pass clean under `SANITIZE=address,undefined`.
- `tests/bench_pool_contention.c` (manual only, not wired into `make test`)
  is the throughput probe behind the numbers in the doc.

## Status

Experimental / opt-in / default off. Open questions (real CI benchmark run,
a sensible default N if ever promoted, cross-shard FIFO ordering trade-off)
are listed at the end of `docs/classic-pool-sharding.md`.
