### PR TITLE
fix(sstring): synchronize string size and detach borrowed buffers in rtrim and ltrim

### DIFF
--- a/src/core/sstring/sstring.c
+++ b/src/core/sstring/sstring.c
@@ -267,8 +267,19 @@ cwist_error_t cwist_sstring_ltrim(cwist_sstring *str) {
     }
 
     if (start > 0) {
-        memmove(str->data, str->data + start, len - start + 1);
-        str->size -= start; 
+        if (str->borrows_buffer) {
+            char *new_data = cwist_sstring_reserve(str, len - start, 0);
+            if (!new_data) {
+                err.error.err_i8 = ERR_SSTRING_NULL_STRING;
+                return err;
+            }
+            memcpy(new_data, str->data + start, len - start + 1);
+            str->data = new_data;
+            str->borrows_buffer = false;
+        } else {
+            memmove(str->data, str->data + start, len - start + 1);
+        }
+        str->size = len - start; 
     }
 
     err.error.err_i8 = ERR_SSTRING_OKAY;
@@ -297,8 +308,19 @@ cwist_error_t cwist_sstring_rtrim(cwist_sstring *str) {
         isspace((unsigned char)str->data[end])) { 
         end--;
     }
+
+    if (str->borrows_buffer) {
+        char *new_data = cwist_sstring_reserve(str, end + 1, end + 1);
+        if (!new_data) {
+            err.error.err_i8 = ERR_SSTRING_NULL_STRING;
+            return err;
+        }
+        str->data = new_data;
+        str->borrows_buffer = false;
+    }
     
     str->data[end + 1] = '\0';
+    str->size = end + 1;
     
     err.error.err_i8 = ERR_SSTRING_OKAY;
     return err;

--- a/tests/test_sstring.c
+++ b/tests/test_sstring.c
@@ -12,10 +12,42 @@ void test_trim() {
 
     cwist_sstring_assign(s, "   hello world   ");
     assert(strcmp(s->data, "   hello world   ") == 0);
+    assert(cwist_sstring_get_size(s) == 17);
 
     cwist_sstring_trim(s);
     printf("Trimmed: '%s'\n", s->data);
     assert(strcmp(s->data, "hello world") == 0);
+    assert(s->size == 11);
+    assert(cwist_sstring_get_size(s) == 11);
+
+    /* Test rtrim alone updates size */
+    cwist_sstring_assign(s, "abc   ");
+    assert(cwist_sstring_get_size(s) == 6);
+    cwist_sstring_rtrim(s);
+    assert(strcmp(s->data, "abc") == 0);
+    assert(s->size == 3);
+    assert(cwist_sstring_get_size(s) == 3);
+
+    /* Test whitespace-only string */
+    cwist_sstring_assign(s, "    ");
+    cwist_sstring_trim(s);
+    assert(strcmp(s->data, "") == 0);
+    assert(s->size == 0);
+    assert(cwist_sstring_get_size(s) == 0);
+
+    /* Test trimming borrowed buffer safely detaches without mutating borrowed memory */
+    const char *orig = "   borrowed text   ";
+    char borrowed_copy[32];
+    strcpy(borrowed_copy, orig);
+    cwist_sstring_borrow(s, borrowed_copy, strlen(borrowed_copy));
+    assert(s->borrows_buffer == true);
+
+    cwist_sstring_trim(s);
+    assert(strcmp(s->data, "borrowed text") == 0);
+    assert(s->size == 13);
+    assert(cwist_sstring_get_size(s) == 13);
+    assert(s->borrows_buffer == false); /* safely detached */
+    assert(strcmp(borrowed_copy, orig) == 0); /* original borrowed source remains intact */
 
     cwist_sstring_destroy(s);
     printf("Passed trim.\n");


### PR DESCRIPTION
## Summary
This PR fixes two related correctness and memory safety issues in `cwist_sstring` trimming:

1. **Size desynchronization in `rtrim`**:
   - `cwist_sstring_rtrim()` set `str->data[end + 1] = '\0'` when trimming trailing whitespace, but never updated `str->size`.
   - As a result, `cwist_sstring_get_size()` and any subsequent operations relying on `str->size` (e.g. `append`, `change_size`, copy) remained stale with the pre-trimmed length.
   - Fixed by updating `str->size = end + 1` after truncation.

2. **Borrowed buffer detachment**:
   - When `str->borrows_buffer` was true (such as from `cwist_sstring_borrow()`), `cwist_sstring_rtrim()` and `cwist_sstring_ltrim()` previously mutated `str->data` in place. This violated the immutability guarantee for external/static storage and would trigger a crash if the borrowed buffer resided in read-only memory.
   - Fixed by checking `str->borrows_buffer` and cleanly detaching the buffer via `cwist_sstring_reserve()` before mutating.

3. **Tests**:
   - Extended `test_trim()` in `tests/test_sstring.c` to verify `cwist_sstring_get_size()` matches the post-trimmed length for both `trim` and `rtrim`.
   - Added verification for whitespace-only strings (`"    "` -> empty string, size 0).
   - Added verification that trimming borrowed buffers safely detaches without mutating the caller's original borrowed memory.

## Testing
- Unit tests compiled and passed without warnings or errors. Target branch: `dev`.
