### PR TITLE
fix(json_heal): preserve commas inside string literals during trailing comma healing

### DIFF
--- a/src/core/utils/json_heal.c
+++ b/src/core/utils/json_heal.c
@@ -79,8 +79,25 @@ static void log_append(char *log, size_t log_sz, const char *msg) {
 static void remove_trailing_commas(strbuf_t *b) {
     char  *d   = b->data;
     size_t len = b->len;
-    for (size_t i = 1; i < len; i++) {
-        if (d[i] == ']' || d[i] == '}') {
+    bool in_str = false;
+    bool esc = false;
+    for (size_t i = 0; i < len; i++) {
+        char c = d[i];
+        if (esc) {
+            esc = false;
+            continue;
+        }
+        if (c == '\\' && in_str) {
+            esc = true;
+            continue;
+        }
+        if (c == '"') {
+            in_str = !in_str;
+            continue;
+        }
+        if (in_str) continue;
+
+        if (c == ']' || c == '}') {
             /* find last non-whitespace before i */
             size_t j = i;
             while (j > 0 && (d[j-1] == ' ' || d[j-1] == '\t' ||

--- a/tests/test_json_heal.c
+++ b/tests/test_json_heal.c
@@ -65,6 +65,30 @@ static void test_l1_trailing_comma(void) {
     printf("  Passed.\n");
 }
 
+static void test_l1_string_with_comma_and_closer(void) {
+    printf("L1: comma followed by closer inside string literal preserved...\n");
+    const char *input = "{\"query\":\"SELECT a, } FROM t\",\"items\":[\"x, ]\", 1,]}";
+    cwist_heal_result_t r = cwist_json_heal(input, NULL);
+    assert(r.json   != NULL);
+    assert(r.healed == true);
+    assert(r.level  == 1);
+
+    cJSON *parsed = cJSON_Parse(r.json);
+    assert(parsed != NULL);
+    cJSON *q = cJSON_GetObjectItem(parsed, "query");
+    assert(q && strcmp(q->valuestring, "SELECT a, } FROM t") == 0);
+    cJSON *items = cJSON_GetObjectItem(parsed, "items");
+    assert(items && cJSON_GetArraySize(items) == 2);
+    cJSON *item0 = cJSON_GetArrayItem(items, 0);
+    assert(item0 && strcmp(item0->valuestring, "x, ]") == 0);
+    cJSON *item1 = cJSON_GetArrayItem(items, 1);
+    assert(item1 && item1->valueint == 1);
+    cJSON_Delete(parsed);
+
+    cwist_heal_result_free(&r);
+    printf("  Passed.\n");
+}
+
 static void test_l1_missing_closers(void) {
     printf("L1: missing closing brace and bracket...\n");
     const char *input = "{\"items\":[1,2,3";
@@ -438,6 +462,7 @@ int main(void) {
     printf("=== L1 Syntax Healing ===\n");
     test_l1_already_valid();
     test_l1_trailing_comma();
+    test_l1_string_with_comma_and_closer();
     test_l1_missing_closers();
     test_l1_line_comment();
     test_l1_bom();


### PR DESCRIPTION
## Summary
This PR fixes an issue in \`cwist_json_heal\` where trailing comma removal erroneously stripped commas from inside JSON string literals.

### Details
- In \`src/core/utils/json_heal.c\`, \`remove_trailing_commas()\` scans for \`,\` before closing brackets (\`]\`) or braces (\`}\`).
- Previously, it did not track string literal context or escape sequences (\`in_str\` and \`esc\`), unlike \`balance_brackets()\` and the comment stripper in the same pipeline.
- As a result, valid string literals containing commas immediately followed by closing braces/brackets (e.g. \`{\"query\": \"SELECT a, } FROM tbl\"}\` or \`{\"pattern\": \"[a, ]\"}\`) had their internal commas removed, corrupting the payload.
- Fixed by tracking string state (\`in_str\`, \`esc\`) inside \`remove_trailing_commas()\`, ignoring characters inside quotes.

### Tests
- Added \`test_l1_string_with_comma_and_closer()\` to \`tests/test_json_heal.c\` validating that string literals with commas followed by braces/brackets remain intact while true trailing commas outside strings are safely cleaned up.
