### PR TITLE
fix(seq): preserve max_data_len limit across assembler resets

### DIFF
--- a/src/core/seq/seq.c
+++ b/src/core/seq/seq.c
@@ -150,10 +150,12 @@ void cwist_seq_assembler_destroy(cwist_seq_assembler_t *a) {
 
 void cwist_seq_assembler_reset(cwist_seq_assembler_t *a) {
     if (!a) return;
+    size_t max_data_len = a->max_data_len;
     cwist_free(a->data);
     cwist_free(a->received);
     cwist_free(a->payload_lens);
     memset(a, 0, sizeof(*a));
+    a->max_data_len = max_data_len;
 }
 
 bool cwist_seq_assembler_feed(cwist_seq_assembler_t *a, const cwist_seq_chunk_t *chunk) {

--- a/tests/test_seq.c
+++ b/tests/test_seq.c
@@ -170,6 +170,37 @@ static void test_conflicting_duplicate_rejected(void) {
     printf("  Passed conflicting duplicate rejection.\n");
 }
 
+static void test_reset_preserves_limit(void) {
+    printf("Testing reset preserves max_data_len limit...\n");
+    /* Create assembler with 10-byte ceiling */
+    cwist_seq_assembler_t *a = cwist_seq_assembler_create_limited(10);
+    assert(a != NULL);
+
+    /* Valid 4-byte message fits within 10-byte limit */
+    const char *msg1 = "test";
+    cwist_seq_message_t split1;
+    assert(cwist_seq_split((const uint8_t *)msg1, strlen(msg1), 4, &split1));
+    cwist_seq_chunk_t chunk;
+    assert(cwist_seq_chunk_parse(split1.chunks[0], split1.chunk_lens[0], &chunk));
+    assert(cwist_seq_assembler_feed(a, &chunk));
+    assert(cwist_seq_assembler_is_complete(a));
+    cwist_seq_message_free(&split1);
+
+    /* Reset the assembler */
+    cwist_seq_assembler_reset(a);
+
+    /* Oversized message (20 bytes > 10-byte ceiling) must still be rejected after reset */
+    const char *msg2 = "01234567890123456789";
+    cwist_seq_message_t split2;
+    assert(cwist_seq_split((const uint8_t *)msg2, strlen(msg2), 10, &split2));
+    assert(cwist_seq_chunk_parse(split2.chunks[0], split2.chunk_lens[0], &chunk));
+    assert(!cwist_seq_assembler_feed(a, &chunk)); /* rejected because 20 > 10 */
+
+    cwist_seq_assembler_destroy(a);
+    cwist_seq_message_free(&split2);
+    printf("  Passed reset preserves limit.\n");
+}
+
 int main(void) {
     test_split_and_reassemble();
     test_duplicate_discard();
@@ -177,6 +208,7 @@ int main(void) {
     test_single_chunk();
     test_final_chunk_first_recovery_targets();
     test_conflicting_duplicate_rejected();
+    test_reset_preserves_limit();
     printf("All seq tests passed!\n");
     return 0;
 }


### PR DESCRIPTION
## Summary
This PR preserves the configured \`max_data_len\` memory ceiling across \`cwist_seq_assembler_reset()\`.

### Details
- When a sequenced-message assembler is created via \`cwist_seq_assembler_create_limited(max_data_len)\`, callers specify a maximum reassembled payload limit to protect against memory exhaustion from untrusted peers.
- In \`src/core/seq/seq.c\`, \`cwist_seq_assembler_reset()\` called \`memset(a, 0, sizeof(*a))\`, which inadvertently zeroed out \`a->max_data_len\`.
- Consequently, after a reset, the assembler reverted to the default unconstrained ceiling (\`CWIST_SEQ_MAX_REASSEMBLED_SIZE\`, 64 MiB), bypassing the caller's configured resource limit.
- Fixed by preserving \`a->max_data_len\` across the reset.

### Tests
- Added \`test_reset_preserves_limit()\` in \`tests/test_seq.c\` validating that resetting a limited assembler preserves its \`max_data_len\` limit and continues rejecting chunks from messages that exceed this limit.
