### PR TITLE
fix(cookie): validate hex digits in cookie decode, fix pointer underflow in parser, and add tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -487,6 +487,7 @@ TEST_TARGETS = test_classic_pool_scaling \
                test_static_and_range \
                test_session \
                test_csrf \
+               test_cookie \
                test_waf \
                test_db_pool \
                test_db_memory \
@@ -895,6 +896,10 @@ test_session: $(LIB_NAME) tests/test_session.c
 test_csrf: $(LIB_NAME) tests/test_csrf.c
 	$(CC) $(CFLAGS) -o test_csrf tests/test_csrf.c $(LIB_NAME) $(LIBS)
 	./test_csrf
+
+test_cookie: $(LIB_NAME) tests/test_cookie.c
+	$(CC) $(CFLAGS) -o test_cookie tests/test_cookie.c $(LIB_NAME) $(LIBS)
+	./test_cookie
 
 test_waf: $(LIB_NAME) tests/test_waf.c
 	$(CC) $(CFLAGS) -o test_waf tests/test_waf.c $(LIB_NAME) $(LIBS)

--- a/src/net/http/cookie.c
+++ b/src/net/http/cookie.c
@@ -47,7 +47,9 @@ int cwist_cookie_decode(const char *in, char *out, size_t out_len) {
     size_t j = 0;
     for (size_t i = 0; i < len; i++) {
         if (j >= out_len - 1) return -1;
-        if (in[i] == '%' && i + 2 < len) {
+        if (in[i] == '%' && i + 2 < len &&
+            isxdigit((unsigned char)in[i + 1]) &&
+            isxdigit((unsigned char)in[i + 2])) {
             unsigned int hex;
             if (sscanf(in + i + 1, "%2x", &hex) != 1) {
                 out[j++] = in[i];
@@ -82,12 +84,16 @@ void cwist_cookie_parse(cwist_query_map *map, const char *header) {
             char *name = pair;
             char *value = eq + 1;
             /* trim trailing whitespace on name */
-            char *end = name + strlen(name) - 1;
-            while (end > name && (*end == ' ' || *end == '\t')) *end-- = '\0';
+            size_t nlen = strlen(name);
+            while (nlen > 0 && (name[nlen - 1] == ' ' || name[nlen - 1] == '\t')) {
+                name[--nlen] = '\0';
+            }
 
-            char decoded[4096];
-            if (cwist_cookie_decode(value, decoded, sizeof(decoded)) >= 0) {
-                cwist_query_map_set(map, name, decoded);
+            if (nlen > 0) {
+                char decoded[4096];
+                if (cwist_cookie_decode(value, decoded, sizeof(decoded)) >= 0) {
+                    cwist_query_map_set(map, name, decoded);
+                }
             }
         }
         pair = strtok_r(NULL, ";", &save);

--- a/tests/test_cookie.c
+++ b/tests/test_cookie.c
@@ -1,0 +1,136 @@
+/**
+ * @file test_cookie.c
+ * @brief Unit tests for HTTP cookie parsing, encoding, decoding, and header generation.
+ */
+
+#include <cwist/net/http/cookie.h>
+#include <cwist/net/http/http.h>
+#include <cwist/net/http/query.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+
+static void test_cookie_encode(void) {
+    printf("Testing cookie encode...\n");
+    char *encoded = cwist_cookie_encode("hello world; test=1");
+    assert(encoded != NULL);
+    assert(strstr(encoded, "%20") != NULL);
+    assert(strstr(encoded, "%3B") != NULL);
+    assert(strstr(encoded, "%3D") != NULL);
+    free(encoded);
+
+    /* Clean alphanumeric should not change */
+    char *clean = cwist_cookie_encode("abc-123_xyz.~");
+    assert(clean != NULL);
+    assert(strcmp(clean, "abc-123_xyz.~") == 0);
+    free(clean);
+    printf("  Passed encode.\n");
+}
+
+static void test_cookie_decode(void) {
+    printf("Testing cookie decode...\n");
+    char out[128];
+
+    /* Basic hex decoding and + as space */
+    int len = cwist_cookie_decode("hello+world%21%2A", out, sizeof(out));
+    assert(len == 13);
+    assert(strcmp(out, "hello world!*") == 0);
+
+    /* Lowercase hex */
+    len = cwist_cookie_decode("%2fpath%2fa", out, sizeof(out));
+    assert(len == 7);
+    assert(strcmp(out, "/path/a") == 0);
+
+    /* Incomplete/malformed percent sequences treated safely as literal */
+    len = cwist_cookie_decode("abc%1gdef%", out, sizeof(out));
+    assert(len > 0);
+    assert(strcmp(out, "abc%1gdef%") == 0);
+
+    /* Small buffer overflow protection */
+    char small[4];
+    int rc = cwist_cookie_decode("toolongstring", small, sizeof(small));
+    assert(rc == -1);
+
+    printf("  Passed decode.\n");
+}
+
+static void test_cookie_parse_and_get(void) {
+    printf("Testing cookie parse and get...\n");
+    cwist_query_map *map = cwist_query_map_create();
+    assert(map != NULL);
+
+    const char *header = "session_id=s%20123; user=alice; theme=dark; ; =empty;   spaced   =value  ";
+    cwist_cookie_parse(map, header);
+
+    const char *session = cwist_cookie_get(map, "session_id");
+    assert(session != NULL && strcmp(session, "s 123") == 0);
+
+    const char *user = cwist_cookie_get(map, "user");
+    assert(user != NULL && strcmp(user, "alice") == 0);
+
+    const char *theme = cwist_cookie_get(map, "theme");
+    assert(theme != NULL && strcmp(theme, "dark") == 0);
+
+    const char *spaced = cwist_cookie_get(map, "spaced");
+    assert(spaced != NULL && strcmp(spaced, "value  ") == 0);
+
+    /* Empty name or missing cookies should return NULL */
+    assert(cwist_cookie_get(map, "") == NULL);
+    assert(cwist_cookie_get(map, "missing") == NULL);
+
+    cwist_query_map_destroy(map);
+    printf("  Passed parse and get.\n");
+}
+
+static void test_cookie_set_and_delete(void) {
+    printf("Testing cookie set and delete...\n");
+    cwist_http_response *res = cwist_http_response_create();
+    assert(res != NULL);
+
+    cwist_cookie_options opts = {
+        .path = "/api",
+        .domain = "example.com",
+        .max_age_seconds = 3600,
+        .http_only = true,
+        .secure = true,
+        .same_site = "Lax",
+    };
+
+    int rc = cwist_cookie_set(res, "auth_token", "xyz 789", &opts);
+    assert(rc == 0);
+
+    const char *set_cookie = cwist_http_header_get(res->headers, "Set-Cookie");
+    assert(set_cookie != NULL);
+    assert(strstr(set_cookie, "auth_token=xyz%20789") != NULL);
+    assert(strstr(set_cookie, "Path=/api") != NULL);
+    assert(strstr(set_cookie, "Domain=example.com") != NULL);
+    assert(strstr(set_cookie, "Max-Age=3600") != NULL);
+    assert(strstr(set_cookie, "HttpOnly") != NULL);
+    assert(strstr(set_cookie, "Secure") != NULL);
+    assert(strstr(set_cookie, "SameSite=Lax") != NULL);
+
+    /* Delete cookie */
+    cwist_http_response *del_res = cwist_http_response_create();
+    assert(del_res != NULL);
+    rc = cwist_cookie_delete(del_res, "auth_token");
+    assert(rc == 0);
+
+    const char *del_cookie = cwist_http_header_get(del_res->headers, "Set-Cookie");
+    assert(del_cookie != NULL);
+    assert(strstr(del_cookie, "auth_token=;") != NULL);
+    assert(strstr(del_cookie, "Max-Age=0") != NULL);
+
+    cwist_http_response_destroy(res);
+    cwist_http_response_destroy(del_res);
+    printf("  Passed set and delete.\n");
+}
+
+int main(void) {
+    test_cookie_encode();
+    test_cookie_decode();
+    test_cookie_parse_and_get();
+    test_cookie_set_and_delete();
+    printf("All cookie tests passed!\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
This PR fixes decoding robustness and parser pointer safety in \`cwist_cookie\`, and adds a dedicated unit test suite for the cookie module.

### Details
1. **Hex validation in \`cwist_cookie_decode()\`**:
   - Previously, \`cwist_cookie_decode()\` called \`sscanf(in + i + 1, "%2x", &hex)\` whenever it encountered \`%\` without verifying that both following characters were valid hexadecimal digits.
   - For incomplete/malformed sequences such as \`%1g\`, \`sscanf\` matched the single hex digit \`1\` and consumed 2 characters, skipping \`g\` and corrupting output.
   - Fixed by requiring \`isxdigit()\` on both characters following \`%\`, leaving non-hex sequences as safe literals.

2. **Pointer bounds safety in \`cwist_cookie_parse()\`**:
   - Trimming trailing whitespace on \`name\` computed \`char *end = name + strlen(name) - 1\`. When \`name\` was empty (e.g. \`; =val\`), \`name - 1\` resulted in out-of-bounds pointer arithmetic before the array boundary (undefined behavior in C).
   - Fixed by using safe length-based index bounds checks and ignoring empty cookie names.

3. **New unit test suite and Makefile integration**:
   - Added \`tests/test_cookie.c\` covering:
     - URL-encoding and decoding (valid hex, lowercase/uppercase, \`+\` as space, invalid/incomplete percent sequences, small buffer overflow protection)
     - Cookie header parsing into \`cwist_query_map\` (whitespace trimming, multiple cookies, empty tokens)
     - Cookie setting with full options (\`Path\`, \`Domain\`, \`Max-Age\`, \`HttpOnly\`, \`Secure\`, \`SameSite\`) and deletion (\`Max-Age=0\`).
   - Wired \`test_cookie\` into \`TEST_TARGETS\` in \`Makefile\`.
