### PR TITLE
chore: cherry-pick recent dev fixes to main

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -34,6 +34,10 @@ jobs:
         make clean
         make -j$(nproc) SANITIZE=address,undefined WERROR=1
         make SANITIZE=address,undefined WERROR=1 test
+        # Do not let an unavailable io_uring backend silently validate only
+        # epoll: completion posting must wake the real ring without a timeout.
+        CWIST_TEST_REQUIRE_IO_URING=1 make SANITIZE=address,undefined WERROR=1 test_reactor_wake
+        CWIST_REACTOR_BACKEND=epoll make SANITIZE=address,undefined WERROR=1 test_reactor_wake
       env:
         ASAN_OPTIONS: detect_leaks=1:abort_on_error=1:halt_on_error=1
         LSAN_OPTIONS: suppressions=tests/lsan.supp

--- a/.github/workflows/bsd-kqueue-benchmarks.yml
+++ b/.github/workflows/bsd-kqueue-benchmarks.yml
@@ -313,6 +313,15 @@ jobs:
           run_bench "CWIST (classic)" "env CWIST_C1M_MODE=0 /tmp/cwist_server" 9091 "/tmp/cwist.txt" "/tmp/cwist_stat.txt" 10
           run_bench "CWIST C1M" "env CWIST_C1M_MODE=1 /tmp/cwist_server" 9091 "/tmp/cwist_c1m.txt" "/tmp/cwist_c1m_stat.txt" 10
 
+          # Experimental: cap glibc's per-process malloc arena count to 1
+          # before the fork loop (src/sys/app/app.c), inherited by every
+          # worker (see issue #25's mimalloc writeup - this targets the same
+          # "N processes x M arenas" RSS/tail-latency multiplication mimalloc
+          # tried to fix, without mimalloc's eager per-process reservation).
+          # Same binary/config as "CWIST C1M" above; the env var is the only
+          # variable, so this is a direct A/B, not a new configuration.
+          run_bench "CWIST C1M (arena_max=1)" "env CWIST_C1M_MODE=1 CWIST_MALLOC_ARENA_MAX=1 /tmp/cwist_server" 9091 "/tmp/cwist_c1m_arena1.txt" "/tmp/cwist_c1m_arena1_stat.txt" 10
+
           # Tuned low-latency profile (CWIST classic only): lower connection
           # pressure (c100, 4 wrk threads) so the per-request latency floor is
           # visible alongside the c400 throughput numbers.
@@ -496,6 +505,9 @@ jobs:
           cwist_c1m_rps, cwist_c1m_lat, cwist_c1m_p50, cwist_c1m_p90, cwist_c1m_p99, cwist_c1m_p99_999 = parse_wrk("/tmp/cwist_c1m.txt")
           cwist_c1m_rss, cwist_c1m_csw = parse_stat("/tmp/cwist_c1m_stat.txt")
 
+          cwist_c1m_arena1_rps, cwist_c1m_arena1_lat, cwist_c1m_arena1_p50, cwist_c1m_arena1_p90, cwist_c1m_arena1_p99, cwist_c1m_arena1_p99_999 = parse_wrk("/tmp/cwist_c1m_arena1.txt")
+          cwist_c1m_arena1_rss, cwist_c1m_arena1_csw = parse_stat("/tmp/cwist_c1m_arena1_stat.txt")
+
           cwist_tuned_rps, cwist_tuned_lat, cwist_tuned_p50, cwist_tuned_p90, cwist_tuned_p99, cwist_tuned_p99_999 = parse_wrk("/tmp/cwist_tuned.txt")
 
           axum_rps, axum_lat, axum_p50, axum_p90, axum_p99, axum_p99_999 = parse_wrk("/tmp/axum.txt")
@@ -513,6 +525,9 @@ jobs:
               "timestamp": datetime.now(timezone.utc).isoformat(),
               "cwist_rps": cwist_rps, "cwist_lat_ms": cwist_lat, "cwist_p90_ms": cwist_p90, "cwist_p99_ms": cwist_p99, "cwist_p99_999_ms": cwist_p99_999, "cwist_rss_kib": cwist_rss, "cwist_csw": cwist_csw,
               "cwist_c1m_rps": cwist_c1m_rps, "cwist_c1m_lat_ms": cwist_c1m_lat, "cwist_c1m_p90_ms": cwist_c1m_p90, "cwist_c1m_p99_ms": cwist_c1m_p99, "cwist_c1m_p99_999_ms": cwist_c1m_p99_999, "cwist_c1m_rss_kib": cwist_c1m_rss, "cwist_c1m_csw": cwist_c1m_csw,
+              # Same C1M binary/config as cwist_c1m_* above, CWIST_MALLOC_ARENA_MAX=1 -
+              # only variable is the env var, direct A/B (see issue #25).
+              "cwist_c1m_arena1_rps": cwist_c1m_arena1_rps, "cwist_c1m_arena1_lat_ms": cwist_c1m_arena1_lat, "cwist_c1m_arena1_p90_ms": cwist_c1m_arena1_p90, "cwist_c1m_arena1_p99_ms": cwist_c1m_arena1_p99, "cwist_c1m_arena1_p99_999_ms": cwist_c1m_arena1_p99_999, "cwist_c1m_arena1_rss_kib": cwist_c1m_arena1_rss, "cwist_c1m_arena1_csw": cwist_c1m_arena1_csw,
               "cwist_tuned_rps": cwist_tuned_rps, "cwist_tuned_lat_ms": cwist_tuned_lat, "cwist_tuned_p50_ms": cwist_tuned_p50, "cwist_tuned_p90_ms": cwist_tuned_p90, "cwist_tuned_p99_ms": cwist_tuned_p99, "cwist_tuned_p99_999_ms": cwist_tuned_p99_999,
               "axum_rps": axum_rps, "axum_lat_ms": axum_lat, "axum_p90_ms": axum_p90, "axum_p99_ms": axum_p99, "axum_p99_999_ms": axum_p99_999, "axum_rss_kib": axum_rss, "axum_csw": axum_csw,
               "gin_rps": gin_rps, "gin_lat_ms": gin_lat, "gin_p90_ms": gin_p90, "gin_p99_ms": gin_p99, "gin_p99_999_ms": gin_p99_999, "gin_rss_kib": gin_rss, "gin_csw": gin_csw,
@@ -544,7 +559,7 @@ jobs:
       - name: Copy raw benchmark output
         run: |
           mkdir -p raw_logs
-          cp /tmp/cwist.txt /tmp/cwist_stat.txt /tmp/cwist_c1m.txt /tmp/cwist_c1m_stat.txt /tmp/cwist_tuned.txt /tmp/axum.txt /tmp/axum_stat.txt /tmp/gin.txt /tmp/gin_stat.txt /tmp/spring.txt /tmp/spring_stat.txt /tmp/spring_tuned.txt /tmp/spring_gc.log raw_logs/ 2>/dev/null || true
+          cp /tmp/cwist.txt /tmp/cwist_stat.txt /tmp/cwist_c1m.txt /tmp/cwist_c1m_stat.txt /tmp/cwist_c1m_arena1.txt /tmp/cwist_c1m_arena1_stat.txt /tmp/cwist_tuned.txt /tmp/axum.txt /tmp/axum_stat.txt /tmp/gin.txt /tmp/gin_stat.txt /tmp/spring.txt /tmp/spring_stat.txt /tmp/spring_tuned.txt /tmp/spring_gc.log raw_logs/ 2>/dev/null || true
       - uses: actions/upload-artifact@v4
         with:
           name: webserver-result

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.o
 *.a
 *.so
+tutorials/*/build/
 
 # Test binaries
 test_sstring

--- a/Makefile
+++ b/Makefile
@@ -452,7 +452,8 @@ $(CNATS_LIB):
 
 # --- Test Targets ---
 
-TEST_TARGETS = test_sstring \
+TEST_TARGETS = test_reactor_wake \
+               test_sstring \
                test_seq \
                test_seq_auth \
                test_http \
@@ -526,6 +527,12 @@ bench_security_pool: $(LIB_NAME) tests/bench_security_pool.c
 	./bench_security_pool
 
 test: $(TEST_TARGETS)
+
+# Kernel/queue contract test: use the real reactor with a test-only allocator,
+# without pulling HTTP/TLS or libttak runtime state into the wake-up schedule.
+test_reactor_wake: tests/test_reactor_wake.c src/sys/io/reactor.c
+	$(CC) $(CFLAGS) -o $@ tests/test_reactor_wake.c -pthread
+	./$@
 
 test_sstring: $(LIB_NAME) tests/test_sstring.c
 	$(CC) $(CFLAGS) -o test_sstring tests/test_sstring.c $(LIB_NAME) $(LIBS)

--- a/Makefile
+++ b/Makefile
@@ -453,6 +453,7 @@ $(CNATS_LIB):
 # --- Test Targets ---
 
 TEST_TARGETS = test_reactor_wake \
+               test_classic_pool_scaling \
                test_sstring \
                test_seq \
                test_seq_auth \
@@ -533,6 +534,13 @@ test: $(TEST_TARGETS)
 test_reactor_wake: tests/test_reactor_wake.c src/sys/io/reactor.c
 	$(CC) $(CFLAGS) -o $@ tests/test_reactor_wake.c -pthread
 	./$@
+
+test_classic_pool_scaling: $(LIB_NAME) tests/test_classic_pool_scaling.c
+	$(CC) $(CFLAGS) -o $@ tests/test_classic_pool_scaling.c $(LIB_NAME) $(LIBS)
+	./$@ burst
+	./$@ multi
+	./$@ cap
+	./$@ failure
 
 test_sstring: $(LIB_NAME) tests/test_sstring.c
 	$(CC) $(CFLAGS) -o test_sstring tests/test_sstring.c $(LIB_NAME) $(LIBS)

--- a/docs/GC.md
+++ b/docs/GC.md
@@ -1,9 +1,11 @@
 # Full GC: Automatic Resource Reclamation in CWIST
 
-Status: **planned for v3.5** (initial work started). This document is the
-design contract for the full-GC mode; until the feature lands, the explicit
-destroy-family model described in the API docs remains the only supported
-lifecycle.
+Status: **implemented, opt-in** (`src/core/mem/gc.c`, `include/cwist/core/mem/gc.h`).
+`cwist_full_gc(true)` is a real, callable toggle today, not a future one —
+see Tutorial 30 (`tutorials/30-graceful-shutdown/`) for a minimal example.
+This document remains the design contract for what the mode does and does
+not cover; the explicit destroy-family model stays fully supported (and is
+the default) whether or not full-GC mode is ever enabled.
 
 ## Motivation
 

--- a/docs/classic-pool-starvation.md
+++ b/docs/classic-pool-starvation.md
@@ -1,0 +1,94 @@
+# Classic pool burst starvation (#25 follow-up)
+
+This is a liveness repair, not a claim that the original HTTP P99.999 report
+has been resolved. It is independent of the io_uring wake-up repair in #37.
+
+## Cause and change
+
+A condition-variable worker remains counted as idle until it wakes and
+reacquires the queue mutex. Previously, submission only grew the classic
+pool when `idle_workers == 0`. A burst could queue several connections while
+one signalled worker still counted idle; once it started a long-lived
+keep-alive handler, the remaining connections had no worker and no further
+submission to trigger growth.
+
+Submission now compares **queued demand against idle capacity** under the
+queue mutex. The maximum-worker check and thread reservation occur in that
+same critical section, so concurrent submitters cannot reserve the same
+remaining slot. It still attempts at most one growth per submission and
+keeps the existing two-attempt thread-creation failure rollback.
+
+No pool defaults, public interfaces, reactor backend, allocator, or pipeline
+budget change. Failed creation can still leave work for existing workers;
+this does not promise progress when resources are exhausted and every
+existing handler is blocked. Existing detached-worker shutdown behavior is
+outside this repair.
+
+## Deterministic regression
+
+`make WERROR=1 test_classic_pool_scaling` runs four separate processes:
+
+- One delayed idle worker and eight held handlers: all eight must start
+  **before any handler completes**. The old code starts only one.
+- Three delayed idle workers: the burst still needs eight concurrent entries.
+- Concurrent submitters with a four-worker cap: no cap overshoot; all eight
+  tasks finish once the four active handlers are released.
+- Two injected `pthread_create` failures: one reservation rolls back, seven
+  handlers can start, and all eight finish after release.
+
+The harness executes production queue code. It delays the condition-wait
+reacquisition and makes captured worker threads joinable solely for safe test
+cleanup; it does not claim to test production detached-worker shutdown.
+The test is included in the normal `make test` suite.
+
+## Validation status
+
+On the local ARM64 Linux environment, the `-Werror` build succeeded. Running
+all 57 Makefile test targets with `make -k WERROR=1 test` produced 56 passes
+and one failure: `test_grpc.c:243`, the `append_grpc_string_frame` append
+assertion. Rebuilding with the original `dev` HTTP source reproduced the same
+failure. This is an observed pre-existing failure in this environment, not a
+claim that its underlying cause is understood or that the full suite is green.
+
+A clean ASan/UBSan build passed these six targets, with leak detection enabled
+and the repository's existing LSan suppression file:
+`test_classic_pool_scaling`, `test_http`, `test_http_pipeline`,
+`test_http_fairness`, `test_async_defer`, and `test_conn_registry`.
+The four pool modes all passed. Independent static review found no blocking
+candidate defect. Hosted CI must still be reviewed; this remains a draft
+until the outstanding validation concerns are resolved.
+
+## HTTP measurements and limits
+
+Local measurements used a dedicated ARM64 Linux VM (4 vCPUs, 4 GiB, kernel
+6.8.0-117), the repository's fixed empty-GET benchmark, four classic worker
+processes, two load-generator threads, and an FD limit of 65536. Each measured
+20-second run followed 5 seconds of discarded warmup. Three paired rounds at
+64, 256 and 512 connections produced 18 error-free runs after correcting the
+measurement clock. Both sides had #37 applied; this patch changes only the
+classic pool, which does not use that reactor wake-up path.
+
+wrk 4.2.0 (`a211dd5a7050b1f9e8a9870b95513060e72ac4a0`) was built locally
+with its `time_us()` using `clock_gettime(CLOCK_MONOTONIC)` instead of
+`gettimeofday`. Initial system-wrk results were discarded: Lima clock-sync
+logs showed backwards wall-clock steps, and wrk's unsigned latency subtraction
+can classify those as histogram-overflow timeouts. This is a measurement-tool
+adjustment, not a server optimization. wrk's reported percentiles also include
+its built-in synthetic latency correction, not only raw observations.
+
+P99.999 in milliseconds, all three runs (before → after):
+
+- c64: `3.194, 3.185, 3.168` → `5.576, 3.172, 3.160`
+- c256: `3.707, 3.583, 3.573` → `3.690, 3.623, 3.616`
+- c512: `4.256, 4.172, 4.173` → `4.276, 4.165, 4.266`
+
+**No consistent steady-state P99.999 reduction was established.** The c64
+candidate outlier is retained, not hidden. Throughput ranges overlap. Separate
+uncontrolled real-HTTP connection bursts also completed on both versions;
+those runs did not reproduce the held-worker schedule from the deterministic
+test. Completed-request histograms alone cannot prove progress for requests
+that never complete. The original issue's 645.72 ms result has not been
+reproduced with this different hardware, revision and workload setup.
+
+References: [wrk timer and timeout accounting](https://github.com/wg/wrk/blob/4.2.0/src/wrk.c),
+[wrk statistics correction](https://github.com/wg/wrk/blob/4.2.0/src/stats.c).

--- a/docs/reactor-wakeup-regression.md
+++ b/docs/reactor-wakeup-regression.md
@@ -1,0 +1,84 @@
+# io_uring posted-work wake-up regression (#25)
+
+## Scope and cause
+
+This fixes a wake-up regression present in `dev` at
+`6afc4a3a506e6740d93ebb2630de917fafd7dea9`, introduced by `7a67f87d`.
+It is a partial contribution to [#25](https://github.com/c4punks/CWIST/issues/25),
+not evidence that the original HTTP concurrency-64/256/512 P99.999 problem is
+fully resolved.
+
+`IORING_REGISTER_EVENTFD` sends **completion notifications from the ring to an
+eventfd**. Writing that eventfd does not enqueue a CQE or wake a ring waiting
+for completions. The previous code used it in the opposite direction and
+removed the wake fd's input poll. With no unrelated socket activity, posted
+work could therefore wait for the run loop's 100 ms shutdown-check timeout.
+A registered eventfd notification also does not synthesize a CQE with
+`user_data == 0`.
+
+The fix restores the one-shot input poll and its existing callback/re-arm path
+on io_uring. Empty-to-nonempty post-stack wake coalescing remains enabled.
+No public API or connection layout changes are involved.
+
+References:
+
+- [io_uring_register(2), IORING_REGISTER_EVENTFD](https://man7.org/linux/man-pages/man2/io_uring_register.2.html)
+- [io_uring_register_eventfd(3)](https://man7.org/linux/man-pages/man3/io_uring_register_eventfd.3.html)
+
+## Regression test
+
+`test_reactor_wake` compiles the production reactor with a test-only libc
+allocator and shutdown flag. It does not replace kernel polling, eventfd,
+posting, or dispatch. It needs the checked-out libttak headers but does not
+link the HTTP/TLS stack or the libttak allocator runtime.
+
+On io_uring it posts four batches of 128 nodes from a foreign thread, requires
+an actual kernel completion on each batch, and runs production dispatch between
+batches to exercise re-arming. A timeout cannot substitute for a completion;
+a positive submission count alone is not sufficient either. An idle-ring check
+rejects completion-to-eventfd feedback. On all supported backends a further 64
+foreign-thread posts verify exactly-once FIFO delivery on the reactor owner.
+A 30-second alarm is only a hang watchdog, not a performance acceptance gate.
+
+```sh
+git submodule update --init lib/libttak
+CWIST_TEST_REQUIRE_IO_URING=1 make WERROR=1 test_reactor_wake
+CWIST_REACTOR_BACKEND=epoll make WERROR=1 test_reactor_wake
+CWIST_TEST_REQUIRE_IO_URING=1 make WERROR=1 SANITIZE=address,undefined test_reactor_wake
+CWIST_REACTOR_BACKEND=epoll make WERROR=1 SANITIZE=address,undefined test_reactor_wake
+# macOS, native kqueue:
+make CC=clang WERROR=1 SANITIZE=address,undefined test_reactor_wake
+```
+
+Run Linux commands on a host that permits `io_uring_setup`; a container seccomp
+policy may prohibit it. The required-backend variable makes this an explicit
+failure instead of silently testing epoll. Do not retain that variable when
+intentionally testing epoll. The sanitizer CI workflow explicitly tests both
+Linux backends in addition to the existing full suite.
+
+## Component measurement (2026-09-12)
+
+Environment: Linux `6.8.0-117-generic`, GCC `13.3.0`, x86_64 Colima/QEMU guest
+on an ARM64 Mac, 6 configured vCPUs and 12 GiB RAM. This is a shared, emulated
+VM, not a production throughput benchmark. Each binary was built using the
+same test and `-std=gnu11 -O2 -g -Wall -Wextra -Werror -pthread`; only the reactor
+source differed. `--bench` skips the deliberately failing kernel regression
+gate and records `CLOCK_MONOTONIC` time from immediately before posting to
+callback execution. No explicit warm-up, no sockets, one producer and one
+reactor, one sequential outstanding post. The existing 100 ms run-loop timeout
+was unchanged.
+
+Three paired runs, 64 samples each per binary, ordered base/fixed,
+fixed/base, base/fixed:
+
+- Base run medians: 103.955, 103.537, 103.490 ms.
+- Fixed run medians: 0.033433, 0.036471, 0.038093 ms.
+- Across 192 samples per binary, base median/max: 103.787046 / 109.251727 ms.
+- Across 192 samples per binary, fixed median/max: 0.034446 / 0.273538 ms.
+
+The regression gate fails against the base with
+`posted wake did not generate a completion: Timer expired` and passes after
+the fix. Targeted ASan/UBSan checks pass on Linux io_uring, forced epoll, and
+native macOS kqueue. These are component checks, not allocator integration,
+HTTP throughput, or P99.999 measurements. The original issue's HTTP workload
+and production hardware still require separate end-to-end validation.

--- a/scripts/ci/benchmark.py
+++ b/scripts/ci/benchmark.py
@@ -166,6 +166,7 @@ def render() -> None:
 
     cwist_lat_part = get_lat_part("cwist")
     cwist_c1m_lat_part = get_lat_part("cwist_c1m")
+    cwist_c1m_arena1_lat_part = get_lat_part("cwist_c1m_arena1")
     axum_lat_part = get_lat_part("axum")
     gin_lat_part = get_lat_part("gin")
     spring_lat_part = get_lat_part("spring")
@@ -174,6 +175,7 @@ def render() -> None:
         f"Latest Web Server Benchmark ({ws_latest.get('wrk_profile','wrk 12t 400c')}):\n"
         f"- **CWIST (classic pool)**: {ws_latest.get('cwist_rps',0):.0f} req/s | Latency {ws_latest.get('cwist_lat_ms',0):.2f}ms{cwist_lat_part} | RSS {ws_latest.get('cwist_rss_kib',0):.0f}KiB | Csw {ws_latest.get('cwist_csw',0):.0f}\n"
         f"- **CWIST (C1M reactor)**: {ws_latest.get('cwist_c1m_rps',0):.0f} req/s | Latency {ws_latest.get('cwist_c1m_lat_ms',0):.2f}ms{cwist_c1m_lat_part} | RSS {ws_latest.get('cwist_c1m_rss_kib',0):.0f}KiB | Csw {ws_latest.get('cwist_c1m_csw',0):.0f}\n"
+        f"- **CWIST (C1M reactor, arena_max=1)** — experimental, see issue #25: {ws_latest.get('cwist_c1m_arena1_rps',0):.0f} req/s | Latency {ws_latest.get('cwist_c1m_arena1_lat_ms',0):.2f}ms{cwist_c1m_arena1_lat_part} | RSS {ws_latest.get('cwist_c1m_arena1_rss_kib',0):.0f}KiB | Csw {ws_latest.get('cwist_c1m_arena1_csw',0):.0f}\n"
         f"- **Axum**: {ws_latest.get('axum_rps',0):.0f} req/s | Latency {ws_latest.get('axum_lat_ms',0):.2f}ms{axum_lat_part} | RSS {ws_latest.get('axum_rss_kib',0):.0f}KiB | Csw {ws_latest.get('axum_csw',0):.0f}\n"
         f"- **Gin (Go)**: {ws_latest.get('gin_rps',0):.0f} req/s | Latency {ws_latest.get('gin_lat_ms',0):.2f}ms{gin_lat_part} | RSS {ws_latest.get('gin_rss_kib',0):.0f}KiB | Csw {ws_latest.get('gin_csw',0):.0f}\n"
         f"- **Spring Boot**: {ws_latest.get('spring_rps',0):.0f} req/s | Latency {ws_latest.get('spring_lat_ms',0):.2f}ms{spring_lat_part} | RSS {ws_latest.get('spring_rss_kib',0):.0f}KiB | Csw {ws_latest.get('spring_csw',0):.0f}\n"

--- a/src/core/sstring/sstring.c
+++ b/src/core/sstring/sstring.c
@@ -267,8 +267,19 @@ cwist_error_t cwist_sstring_ltrim(cwist_sstring *str) {
     }
 
     if (start > 0) {
-        memmove(str->data, str->data + start, len - start + 1);
-        str->size -= start; 
+        if (str->borrows_buffer) {
+            char *new_data = cwist_sstring_reserve(str, len - start, 0);
+            if (!new_data) {
+                err.error.err_i8 = ERR_SSTRING_NULL_STRING;
+                return err;
+            }
+            memcpy(new_data, str->data + start, len - start + 1);
+            str->data = new_data;
+            str->borrows_buffer = false;
+        } else {
+            memmove(str->data, str->data + start, len - start + 1);
+        }
+        str->size = len - start; 
     }
 
     err.error.err_i8 = ERR_SSTRING_OKAY;
@@ -297,8 +308,19 @@ cwist_error_t cwist_sstring_rtrim(cwist_sstring *str) {
         isspace((unsigned char)str->data[end])) { 
         end--;
     }
+
+    if (str->borrows_buffer) {
+        char *new_data = cwist_sstring_reserve(str, end + 1, end + 1);
+        if (!new_data) {
+            err.error.err_i8 = ERR_SSTRING_NULL_STRING;
+            return err;
+        }
+        str->data = new_data;
+        str->borrows_buffer = false;
+    }
     
     str->data[end + 1] = '\0';
+    str->size = end + 1;
     
     err.error.err_i8 = ERR_SSTRING_OKAY;
     return err;

--- a/src/net/http/http.c
+++ b/src/net/http/http.c
@@ -441,16 +441,20 @@ void cwist_http_pool_submit(int client_fd, void (*handler)(int, void *), void *c
         g_dyn_pool.tail->next = node;
         g_dyn_pool.tail = node;
     }
-    atomic_fetch_add_explicit(&g_dyn_pool.pending_tasks, 1, memory_order_release);
-    pthread_cond_signal(&g_dyn_pool.cond);
-    pthread_mutex_unlock(&g_dyn_pool.lock);
+    long pending = atomic_fetch_add_explicit(&g_dyn_pool.pending_tasks, 1, memory_order_release) + 1;
 
+    /* Signalled sleepers remain counted idle until they reacquire this lock.
+     * Compare queued demand with that capacity, not merely idle == 0: a
+     * burst can otherwise strand connections behind busy keep-alive handlers.
+     * Keep the cap check and the spawn reservation in this critical section. */
     long current = atomic_load_explicit(&g_dyn_pool.active_workers, memory_order_relaxed);
     long idle = atomic_load_explicit(&g_dyn_pool.idle_workers, memory_order_relaxed);
     long max_w = atomic_load_explicit(&g_dyn_pool.max_workers, memory_order_relaxed);
-    if (idle == 0 && current < max_w) {
+    if (pending > idle && current < max_w) {
         http_spawn_worker();
     }
+    pthread_cond_signal(&g_dyn_pool.cond);
+    pthread_mutex_unlock(&g_dyn_pool.lock);
 }
 
 bool cwist_http_pool_rearm_current(int client_fd, void (*handler)(int, void *), void *ctx) {

--- a/src/sys/app/app.c
+++ b/src/sys/app/app.c
@@ -43,6 +43,9 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <poll.h>
+#if defined(__GLIBC__)
+#include <malloc.h>
+#endif
 #include <arpa/inet.h>
 #include <netinet/tcp.h>
 #include <dirent.h>
@@ -3734,6 +3737,36 @@ int cwist_app_listen(cwist_app *app, int port) {
         workers = (cores > 0) ? (int)cores : 1;
     }
     if (workers < 1) workers = 1;
+
+#if defined(__GLIBC__)
+    /* Experimental (issue #25, ROADMAP.md v3.5): cap glibc's per-process
+     * arena count before forking, so the setting is inherited by every
+     * worker. mallopt() state is plain process memory, not something a
+     * live fork() can "share back" afterward - COW means a child's first
+     * write to any inherited page (which malloc always does) forks its own
+     * private copy immediately, so there's no way to keep multiple
+     * processes pointed at one mutable arena. What *is* achievable is
+     * capping how many arenas each process can independently accumulate:
+     * by default glibc lets internal thread contention grow up to
+     * ncpus*8 arenas *per process* (each worker here forks before
+     * creating its own watcher/HTTP-3 threads, so every worker can hit
+     * that ceiling independently) - with N worker processes that's a
+     * multiplicative blow-up, and each extra arena is its own mmap'd
+     * region that adds directly to RSS. CWIST_MALLOC_ARENA_MAX=1 forces
+     * every worker down to its single main arena regardless of how many
+     * threads it spins up afterward. Unset by default: preserves today's
+     * behavior exactly. Not yet measured against the mimalloc A/B in that
+     * issue - this is the next experiment, not a default change. */
+    const char *arena_max_env = getenv("CWIST_MALLOC_ARENA_MAX");
+    if (arena_max_env && arena_max_env[0]) {
+        char *end = NULL;
+        long arena_max = strtol(arena_max_env, &end, 10);
+        if (end && *end == '\0' && arena_max >= 0 && arena_max <= INT_MAX) {
+            mallopt(M_ARENA_MAX, (int)arena_max);
+        }
+    }
+#endif
+
     bool is_worker_child = false;
     pid_t worker_pids[workers > 1 ? workers - 1 : 1];
     size_t worker_count = 0;

--- a/src/sys/io/reactor.c
+++ b/src/sys/io/reactor.c
@@ -55,9 +55,6 @@ static inline int sys_io_uring_enter_timeout(int ring_fd, unsigned to_submit, un
     return (int)syscall(__NR_io_uring_enter, ring_fd, to_submit, min_complete,
                         flags | IORING_ENTER_EXT_ARG, &arg, sizeof(arg));
 }
-static inline int sys_io_uring_register(int ring_fd, unsigned opcode, const void *arg, unsigned nr) {
-    return (int)syscall(__NR_io_uring_register, ring_fd, opcode, arg, nr);
-}
 
 /* Ring setup helpers absorbed from the retired io_uring_backend.c. */
 static void *mmap_ring(int fd, size_t sz, off_t off) {
@@ -96,10 +93,6 @@ typedef struct {
     // epoll fallback
     int epoll_fd;
     bool use_epoll;
-    /* True when wake_fd is registered via IORING_REGISTER_EVENTFD: writes
-     * then post CQEs directly, so the wake fd consumes no one-shot poll
-     * slot and needs no re-arm. */
-    bool wake_registered;
 } reactor_impl_t;
 
 #elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
@@ -221,10 +214,8 @@ bool cwist_reactor_post(cwist_reactor_t *r, cwist_reactor_post_t *node) {
         node->next = head;
     } while (!atomic_compare_exchange_weak_explicit(&r->post_head, &head, node,
                                                     memory_order_release, memory_order_relaxed));
-    /* Wake only on the first post of a pending batch: if the stack was
-     * non-empty a wake CQE is already in flight (or the run thread is
-     * mid-drain and will re-check at the loop top), so extra writes would
-     * only flood the ring with redundant eventfd CQEs. */
+    /* Wake only on the first post of a pending batch. A non-empty stack
+     * already has a wake pending; another write would be redundant. */
     if (head == NULL && r->wake_wr >= 0) {
         uint64_t one = 1;
         ssize_t ign = write(r->wake_wr, &one, sizeof(one));
@@ -312,20 +303,6 @@ cwist_reactor_t *cwist_reactor_create(void) {
             r->impl.cq_entries      = p.cq_entries;
             r->impl.active = true;
 
-            /* Register the wake eventfd with the ring itself: writes post
-             * CQEs directly (user_data == 0), so the wake fd consumes no
-             * one-shot poll slot and needs no re-arm per firing.  On any
-             * failure fall back to the polled wake fd below. */
-            r->wake_fd = eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
-            if (r->wake_fd >= 0 &&
-                sys_io_uring_register(fd, IORING_REGISTER_EVENTFD, &r->wake_fd, 1) == 0) {
-                r->wake_wr = r->wake_fd;
-                r->impl.wake_registered = true;
-            } else if (r->wake_fd >= 0) {
-                close(r->wake_fd);
-                r->wake_fd = -1;
-            }
-
             /* Identity SQE mapping is fixed for the ring's lifetime; fill it
              * once here instead of rewriting sq_array on every submission. */
             for (uint32_t i = 0; i < p.sq_entries; i++) r->impl.sq_array[i] = i;
@@ -358,10 +335,8 @@ cwist_reactor_t *cwist_reactor_create(void) {
 #endif
     atomic_init(&r->post_head, NULL);
 #ifdef __linux__
-    if (!r->impl.wake_registered) {
-        r->wake_fd = eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
-        r->wake_wr = r->wake_fd;
-    }
+    r->wake_fd = eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
+    r->wake_wr = r->wake_fd;
 #else
     r->wake_fd = -1;
     r->wake_wr = -1;
@@ -377,12 +352,11 @@ cwist_reactor_t *cwist_reactor_create(void) {
         }
     }
 #endif
-#ifdef __linux__
-    bool wake_polled = !r->impl.wake_registered;
-#else
-    bool wake_polled = true;
-#endif
-    if (wake_polled && r->wake_fd >= 0 &&
+    /* Poll the wake fd on every backend. IORING_REGISTER_EVENTFD notifies
+     * an external eventfd when CQEs arrive; writes to it do not create CQEs
+     * or interrupt io_uring_enter. The one-shot poll is re-armed by
+     * reactor_wake_cb, including when posts arrive during a dispatch. */
+    if (r->wake_fd >= 0 &&
         !cwist_reactor_add(r, r->wake_fd, reactor_wake_cb, &r, sizeof(r))) {
         /* Wake best-effort: the run loop still drains the stack each round. */
         close(r->wake_fd);
@@ -729,11 +703,6 @@ void cwist_reactor_run(cwist_reactor_t *reactor) {
                         ev_ctx->cb(ev_ctx->fd, ev_ctx->ctx);
                     }
                     free_reactor_ctx(reactor, ev_ctx);
-                } else if (reactor->impl.wake_registered) {
-                    /* Registered eventfd CQE (user_data == 0): drain the
-                     * counter; the posts themselves run at the loop top. */
-                    uint64_t buf[8];
-                    while (read(reactor->wake_fd, buf, sizeof(buf)) > 0) {}
                 }
                 head++;
             }

--- a/tests/test_classic_pool_scaling.c
+++ b/tests/test_classic_pool_scaling.c
@@ -27,7 +27,9 @@ static int joinable_create(pthread_t *, const pthread_attr_t *,
 #define MAX_THREADS (JOBS * 4)
 static pthread_mutex_t gate_mu = PTHREAD_MUTEX_INITIALIZER;
 static pthread_cond_t gate_cv = PTHREAD_COND_INITIALIZER;
-static bool initial_parked, release_initial, release_handlers;
+static int initial_parked, initial_threads = 1;
+static bool release_initial, release_handlers;
+static int fail_creates, failed_creates;
 static int started, finished;
 static bool seen[JOBS];
 static pthread_t threads[MAX_THREADS];
@@ -43,8 +45,8 @@ static struct timespec deadline(void) {
 static int delayed_wait(pthread_cond_t *cond, pthread_mutex_t *mutex) {
     if (cond == &g_dyn_pool.cond) {
         pthread_mutex_lock(&gate_mu);
-        if (!initial_parked) {
-            initial_parked = true;
+        if (initial_parked < initial_threads) {
+            initial_parked++;
             pthread_mutex_unlock(mutex);
             pthread_cond_broadcast(&gate_cv);
             while (!release_initial) pthread_cond_wait(&gate_cv, &gate_mu);
@@ -59,6 +61,14 @@ static int delayed_wait(pthread_cond_t *cond, pthread_mutex_t *mutex) {
 
 static int joinable_create(pthread_t *thread, const pthread_attr_t *attr,
                            void *(*start)(void *), void *arg) {
+    pthread_mutex_lock(&gate_mu);
+    if (fail_creates) {
+        fail_creates--;
+        failed_creates++;
+        pthread_mutex_unlock(&gate_mu);
+        return EAGAIN;
+    }
+    pthread_mutex_unlock(&gate_mu);
     pthread_attr_t joinable;
     assert(pthread_attr_init(&joinable) == 0);
     size_t stack_size;
@@ -89,8 +99,19 @@ static void held_handler(int fd, void *ctx) {
     pthread_mutex_unlock(&gate_mu);
 }
 
-int main(void) {
+static void *submit_one(void *id) {
+    cwist_http_pool_submit(-1, held_handler, id);
+    return NULL;
+}
+
+int main(int argc, char **argv) {
     alarm(15);
+    const char *mode = argc > 1 ? argv[1] : "burst";
+    bool capped = strcmp(mode, "cap") == 0;
+    bool failure = strcmp(mode, "failure") == 0;
+    initial_threads = strcmp(mode, "multi") == 0 ? 3 : 1;
+    int expected = capped ? 4 : failure ? JOBS - 1 : JOBS;
+    cwist_http_pool_limit_core((unsigned int)initial_threads);
     assert(setenv("CWIST_C1M_MODE", "0", 1) == 0);
     assert(setenv("CWIST_WORKER_THREADS", "1", 1) == 0);
     assert(setenv("CWIST_POOL_IDLE_TIMEOUT_MS", "0", 1) == 0);
@@ -98,23 +119,28 @@ int main(void) {
     assert(cwist_http_pool_init() == 0);
     pthread_mutex_lock(&gate_mu);
     struct timespec until = deadline();
-    while (!initial_parked) {
+    while (initial_parked < initial_threads) {
         int rc = pthread_cond_timedwait(&gate_cv, &gate_mu, &until);
         assert(rc == 0);
     }
+    if (capped) atomic_store(&g_dyn_pool.max_workers, 4);
+    if (failure) fail_creates = 2;
     pthread_mutex_unlock(&gate_mu);
 
     int ids[JOBS];
+    pthread_t submitters[JOBS];
     for (int i = 0; i < JOBS; i++) {
         ids[i] = i;
         /* The handler owns no transport in this queue-only regression. */
-        cwist_http_pool_submit(-1, held_handler, &ids[i]);
+        if (capped) assert(pthread_create(&submitters[i], NULL, submit_one, &ids[i]) == 0);
+        else submit_one(&ids[i]);
     }
+    if (capped) for (int i = 0; i < JOBS; i++) assert(pthread_join(submitters[i], NULL) == 0);
     pthread_mutex_lock(&gate_mu);
     release_initial = true;
     pthread_cond_broadcast(&gate_cv);
     until = deadline();
-    while (started < JOBS) {
+    while (started < expected) {
         int rc = pthread_cond_timedwait(&gate_cv, &gate_mu, &until);
         if (rc == ETIMEDOUT) break;
         assert(rc == 0);
@@ -138,10 +164,13 @@ int main(void) {
     for (int i = 0; i < thread_count; i++) assert(pthread_join(threads[i], NULL) == 0);
     assert(atomic_load(&g_http_inflight) == 0);
     assert(atomic_load(&g_dyn_pool.pending_tasks) == 0);
+    assert(atomic_load(&g_dyn_pool.active_workers) == thread_count);
+    if (capped) assert(thread_count <= 4);
+    if (failure) assert(failed_creates == 2 && fail_creates == 0);
     cwist_http_pool_destroy();
     printf("classic burst: %d/%d handlers started before any completion; workers=%d\n",
            started_without_release, JOBS, thread_count);
-    if (started_without_release != JOBS) {
+    if (started_without_release != expected) {
         fputs("FAIL: queued connections starve behind held keep-alive handlers\n", stderr);
         return 1;
     }

--- a/tests/test_classic_pool_scaling.c
+++ b/tests/test_classic_pool_scaling.c
@@ -1,0 +1,150 @@
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+#include <assert.h>
+#include <errno.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include <unistd.h>
+
+/* Hold the first idle worker after its condition wait released the queue
+ * mutex. This models a signalled worker that has not been scheduled yet.
+ * Make pool threads joinable only in this harness so no detached worker can
+ * outlive the synchronization objects during test cleanup. */
+static int delayed_wait(pthread_cond_t *, pthread_mutex_t *);
+static int joinable_create(pthread_t *, const pthread_attr_t *,
+                           void *(*)(void *), void *);
+#define pthread_cond_wait delayed_wait
+#define pthread_create joinable_create
+#include "../src/net/http/http.c"
+#undef pthread_create
+#undef pthread_cond_wait
+
+#define JOBS 8
+#define MAX_THREADS (JOBS * 4)
+static pthread_mutex_t gate_mu = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t gate_cv = PTHREAD_COND_INITIALIZER;
+static bool initial_parked, release_initial, release_handlers;
+static int started, finished;
+static bool seen[JOBS];
+static pthread_t threads[MAX_THREADS];
+static int thread_count;
+
+static struct timespec deadline(void) {
+    struct timespec ts;
+    assert(clock_gettime(CLOCK_REALTIME, &ts) == 0);
+    ts.tv_sec += 3;
+    return ts;
+}
+
+static int delayed_wait(pthread_cond_t *cond, pthread_mutex_t *mutex) {
+    if (cond == &g_dyn_pool.cond) {
+        pthread_mutex_lock(&gate_mu);
+        if (!initial_parked) {
+            initial_parked = true;
+            pthread_mutex_unlock(mutex);
+            pthread_cond_broadcast(&gate_cv);
+            while (!release_initial) pthread_cond_wait(&gate_cv, &gate_mu);
+            pthread_mutex_unlock(&gate_mu);
+            pthread_mutex_lock(mutex);
+            return 0;
+        }
+        pthread_mutex_unlock(&gate_mu);
+    }
+    return pthread_cond_wait(cond, mutex);
+}
+
+static int joinable_create(pthread_t *thread, const pthread_attr_t *attr,
+                           void *(*start)(void *), void *arg) {
+    pthread_attr_t joinable;
+    assert(pthread_attr_init(&joinable) == 0);
+    size_t stack_size;
+    assert(pthread_attr_getstacksize(attr, &stack_size) == 0);
+    assert(pthread_attr_setstacksize(&joinable, stack_size) == 0);
+    int rc = pthread_create(thread, &joinable, start, arg);
+    pthread_attr_destroy(&joinable);
+    if (!rc) {
+        pthread_mutex_lock(&gate_mu);
+        assert(thread_count < MAX_THREADS);
+        threads[thread_count++] = *thread;
+        pthread_mutex_unlock(&gate_mu);
+    }
+    return rc;
+}
+
+static void held_handler(int fd, void *ctx) {
+    (void)fd;
+    int index = *(int *)ctx;
+    pthread_mutex_lock(&gate_mu);
+    assert(index >= 0 && index < JOBS && !seen[index]);
+    seen[index] = true;
+    started++;
+    pthread_cond_broadcast(&gate_cv);
+    while (!release_handlers) pthread_cond_wait(&gate_cv, &gate_mu);
+    finished++;
+    pthread_cond_broadcast(&gate_cv);
+    pthread_mutex_unlock(&gate_mu);
+}
+
+int main(void) {
+    alarm(15);
+    assert(setenv("CWIST_C1M_MODE", "0", 1) == 0);
+    assert(setenv("CWIST_WORKER_THREADS", "1", 1) == 0);
+    assert(setenv("CWIST_POOL_IDLE_TIMEOUT_MS", "0", 1) == 0);
+    assert(unsetenv("CWIST_POOL_PREWARM") == 0);
+    assert(cwist_http_pool_init() == 0);
+    pthread_mutex_lock(&gate_mu);
+    struct timespec until = deadline();
+    while (!initial_parked) {
+        int rc = pthread_cond_timedwait(&gate_cv, &gate_mu, &until);
+        assert(rc == 0);
+    }
+    pthread_mutex_unlock(&gate_mu);
+
+    int ids[JOBS];
+    for (int i = 0; i < JOBS; i++) {
+        ids[i] = i;
+        /* The handler owns no transport in this queue-only regression. */
+        cwist_http_pool_submit(-1, held_handler, &ids[i]);
+    }
+    pthread_mutex_lock(&gate_mu);
+    release_initial = true;
+    pthread_cond_broadcast(&gate_cv);
+    until = deadline();
+    while (started < JOBS) {
+        int rc = pthread_cond_timedwait(&gate_cv, &gate_mu, &until);
+        if (rc == ETIMEDOUT) break;
+        assert(rc == 0);
+    }
+    int started_without_release = started;
+    /* Release only after observing the contract; otherwise one worker could
+     * run all eight handlers serially and disguise the starvation. */
+    release_handlers = true;
+    pthread_cond_broadcast(&gate_cv);
+    until = deadline();
+    while (finished < JOBS) {
+        int rc = pthread_cond_timedwait(&gate_cv, &gate_mu, &until);
+        assert(rc == 0);
+    }
+    pthread_mutex_unlock(&gate_mu);
+
+    pthread_mutex_lock(&g_dyn_pool.lock);
+    atomic_store(&g_dyn_pool.running, false);
+    pthread_cond_broadcast(&g_dyn_pool.cond);
+    pthread_mutex_unlock(&g_dyn_pool.lock);
+    for (int i = 0; i < thread_count; i++) assert(pthread_join(threads[i], NULL) == 0);
+    assert(atomic_load(&g_http_inflight) == 0);
+    assert(atomic_load(&g_dyn_pool.pending_tasks) == 0);
+    cwist_http_pool_destroy();
+    printf("classic burst: %d/%d handlers started before any completion; workers=%d\n",
+           started_without_release, JOBS, thread_count);
+    if (started_without_release != JOBS) {
+        fputs("FAIL: queued connections starve behind held keep-alive handlers\n", stderr);
+        return 1;
+    }
+    puts("classic burst scaling: PASS");
+    return 0;
+}

--- a/tests/test_reactor_wake.c
+++ b/tests/test_reactor_wake.c
@@ -1,0 +1,183 @@
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+/* Standalone reactor/kernel contract test. Include the implementation to
+ * reject io_uring fallback and inspect completion readiness, without adding a
+ * public test API. Only the allocator and process shutdown flag are replaced;
+ * all polling, eventfd, posting, and run-loop code is production code.
+ *
+ * --bench prints post-to-callback samples; timings are diagnostic, not gates.
+ * CWIST_TEST_REQUIRE_IO_URING=1 fails rather than skipping a denied backend.
+ */
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include "../src/sys/io/reactor.c"
+
+void *cwist_alloc(size_t size) { return calloc(1, size); }
+void cwist_free(void *ptr) { free(ptr); }
+atomic_int g_cwist_running = 1;
+
+enum { ROUNDS = 64, BATCH = 128 };
+static cwist_reactor_t *loop;
+static pthread_t owner;
+static cwist_reactor_post_t chain[ROUNDS], finish;
+static struct timespec sent[ROUNDS];
+static double elapsed[ROUNDS];
+static int delivered;
+static pthread_mutex_t mu = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t cv = PTHREAD_COND_INITIALIZER;
+static int requested = -1;
+static bool quitting;
+
+static double milliseconds(struct timespec a, struct timespec b) {
+    return (b.tv_sec - a.tv_sec) * 1000.0 + (b.tv_nsec - a.tv_nsec) / 1e6;
+}
+
+static void noop(void *ctx) { (void)ctx; }
+
+static void request_next(int index) {
+    assert(pthread_mutex_lock(&mu) == 0);
+    requested = index;
+    assert(pthread_cond_signal(&cv) == 0);
+    assert(pthread_mutex_unlock(&mu) == 0);
+}
+
+static void delivered_cb(void *ctx) {
+    int index = (int)(intptr_t)ctx;
+    struct timespec now;
+    assert(pthread_equal(pthread_self(), owner));
+    assert(index == delivered++);
+    assert(clock_gettime(CLOCK_MONOTONIC, &now) == 0);
+    elapsed[index] = milliseconds(sent[index], now);
+    if (index + 1 < ROUNDS) {
+        request_next(index + 1);
+    } else {
+        cwist_reactor_stop(loop);
+        /* stop() does not wake a wait after the top-of-loop post drain.
+         * Queue a final no-op so this test is not about that separate API. */
+        finish.cb = noop;
+        assert(cwist_reactor_post(loop, &finish));
+    }
+}
+
+static void *producer(void *unused) {
+    (void)unused;
+    for (;;) {
+        assert(pthread_mutex_lock(&mu) == 0);
+        while (requested < 0 && !quitting)
+            assert(pthread_cond_wait(&cv, &mu) == 0);
+        if (quitting) {
+            assert(pthread_mutex_unlock(&mu) == 0);
+            return NULL;
+        }
+        int index = requested;
+        requested = -1;
+        assert(pthread_mutex_unlock(&mu) == 0);
+        chain[index].cb = delivered_cb;
+        chain[index].ctx = (void *)(intptr_t)index;
+        assert(clock_gettime(CLOCK_MONOTONIC, &sent[index]) == 0);
+        assert(cwist_reactor_post(loop, &chain[index]));
+    }
+}
+
+#ifdef __linux__
+static void burst_cb(void *ctx) {
+    assert(pthread_equal(pthread_self(), owner));
+    assert((int)(intptr_t)ctx == delivered++);
+    if (delivered == BATCH) cwist_reactor_stop(loop);
+}
+
+static void *burst_producer(void *arg) {
+    cwist_reactor_post_t *nodes = arg;
+    for (int i = 0; i < BATCH; i++) {
+        nodes[i].cb = burst_cb;
+        nodes[i].ctx = (void *)(intptr_t)i;
+        assert(cwist_reactor_post(loop, &nodes[i]));
+    }
+    return NULL;
+}
+#endif
+
+/* A readable post wake must produce a completion, not merely become visible
+ * at the next shutdown polling timeout. No sockets can rescue the wake here.
+ * Repeat on the same ring, using production dispatch to consume/re-arm it. */
+static void check_uring_wake(void) {
+#ifdef __linux__
+    if (loop->impl.use_epoll) return;
+    for (int epoch = 0; epoch < 4; epoch++) {
+        cwist_reactor_post_t nodes[BATCH] = {0};
+        pthread_t thread;
+        delivered = 0;
+        assert(pthread_create(&thread, NULL, burst_producer, nodes) == 0);
+        assert(pthread_join(thread, NULL) == 0);
+        const struct __kernel_timespec deadline = { .tv_sec = 1 };
+        int ret;
+        do {
+            ret = sys_io_uring_enter_timeout(loop->impl.ring_fd,
+                        loop->sq_unsubmitted, 1, IORING_ENTER_GETEVENTS, &deadline);
+        } while (ret < 0 && errno == EINTR);
+        if (ret < 0) {
+            perror("posted wake did not generate a completion");
+            exit(1);
+        }
+        loop->sq_unsubmitted = 0;
+        /* A positive submission count can mask a wait timeout. Require a
+         * real CQE too, including after each production dispatch/re-arm. */
+        assert(__atomic_load_n(loop->impl.cq_tail, __ATOMIC_ACQUIRE) !=
+               __atomic_load_n(loop->impl.cq_head, __ATOMIC_ACQUIRE));
+        cwist_reactor_run(loop);
+        assert(delivered == BATCH);
+    }
+    /* The drained input poll must be idle. Retaining output registration on
+     * the same fd could otherwise feed completions back into themselves. */
+    const struct __kernel_timespec idle = { .tv_nsec = 10000000 };
+    (void)sys_io_uring_enter_timeout(loop->impl.ring_fd,
+                    loop->sq_unsubmitted, 1, IORING_ENTER_GETEVENTS, &idle);
+    loop->sq_unsubmitted = 0;
+    assert(__atomic_load_n(loop->impl.cq_tail, __ATOMIC_ACQUIRE) ==
+           __atomic_load_n(loop->impl.cq_head, __ATOMIC_ACQUIRE));
+#endif
+}
+
+static cwist_reactor_t *create_checked(void) {
+    cwist_reactor_t *r = cwist_reactor_create();
+    assert(r != NULL);
+#ifdef __linux__
+    printf("backend=%s\n", r->impl.use_epoll ? "epoll" : "io_uring");
+    if (r->impl.use_epoll && getenv("CWIST_TEST_REQUIRE_IO_URING")) {
+        fprintf(stderr, "required io_uring backend unavailable\n");
+        cwist_reactor_destroy(r);
+        exit(1);
+    }
+#else
+    puts("backend=kqueue");
+#endif
+    return r;
+}
+
+int main(int argc, char **argv) {
+    bool bench = argc == 2 && strcmp(argv[1], "--bench") == 0;
+    alarm(30); /* Watchdog only, not the correctness oracle. */
+    owner = pthread_self();
+    loop = create_checked();
+    if (!bench) check_uring_wake();
+    cwist_reactor_destroy(loop);
+    loop = create_checked();
+    delivered = 0;
+    pthread_t thread;
+    assert(pthread_create(&thread, NULL, producer, NULL) == 0);
+    request_next(0);
+    cwist_reactor_run(loop);
+    assert(pthread_mutex_lock(&mu) == 0);
+    quitting = true;
+    assert(pthread_cond_signal(&cv) == 0);
+    assert(pthread_mutex_unlock(&mu) == 0);
+    assert(pthread_join(thread, NULL) == 0);
+    assert(delivered == ROUNDS);
+    cwist_reactor_destroy(loop);
+    for (int i = 0; i < ROUNDS; i++) printf("post_ms[%d]=%.6f\n", i, elapsed[i]);
+    puts("reactor wake, repeated re-arm, FIFO and owner-thread delivery: PASS");
+    return 0;
+}

--- a/tests/test_sstring.c
+++ b/tests/test_sstring.c
@@ -12,10 +12,42 @@ void test_trim() {
 
     cwist_sstring_assign(s, "   hello world   ");
     assert(strcmp(s->data, "   hello world   ") == 0);
+    assert(cwist_sstring_get_size(s) == 17);
 
     cwist_sstring_trim(s);
     printf("Trimmed: '%s'\n", s->data);
     assert(strcmp(s->data, "hello world") == 0);
+    assert(s->size == 11);
+    assert(cwist_sstring_get_size(s) == 11);
+
+    /* Test rtrim alone updates size */
+    cwist_sstring_assign(s, "abc   ");
+    assert(cwist_sstring_get_size(s) == 6);
+    cwist_sstring_rtrim(s);
+    assert(strcmp(s->data, "abc") == 0);
+    assert(s->size == 3);
+    assert(cwist_sstring_get_size(s) == 3);
+
+    /* Test whitespace-only string */
+    cwist_sstring_assign(s, "    ");
+    cwist_sstring_trim(s);
+    assert(strcmp(s->data, "") == 0);
+    assert(s->size == 0);
+    assert(cwist_sstring_get_size(s) == 0);
+
+    /* Test trimming borrowed buffer safely detaches without mutating borrowed memory */
+    const char *orig = "   borrowed text   ";
+    char borrowed_copy[32];
+    strcpy(borrowed_copy, orig);
+    cwist_sstring_borrow(s, borrowed_copy, strlen(borrowed_copy));
+    assert(s->borrows_buffer == true);
+
+    cwist_sstring_trim(s);
+    assert(strcmp(s->data, "borrowed text") == 0);
+    assert(s->size == 13);
+    assert(cwist_sstring_get_size(s) == 13);
+    assert(s->borrows_buffer == false); /* safely detached */
+    assert(strcmp(borrowed_copy, orig) == 0); /* original borrowed source remains intact */
 
     cwist_sstring_destroy(s);
     printf("Passed trim.\n");

--- a/tutorials/01-hello-world/CMakeLists.txt
+++ b/tutorials/01-hello-world/CMakeLists.txt
@@ -4,7 +4,7 @@ project(cwist_tut_01 C)
 set(CMAKE_C_STANDARD 11)
 
 include_directories(../../include ../../lib ../../lib/libttak/include)
-link_directories(../../ ../../lib/cjson ../../lib/libttak/lib ../../lib/uriparser/build)
+link_directories(../../ ../../lib/cjson ../../lib/libttak/lib ../../lib/uriparser/build ../../lib/boringssl/build ../../lib/lsquic/build/src/liblsquic ../../lib/cnats/build/lib)
 
 add_executable(tut01 main.c)
-target_link_libraries(tut01 PRIVATE cwist cjson ttak pthread dl uriparser stdc++ m z curl)
+target_link_libraries(tut01 PRIVATE cwist lsquic ssl crypto nats_static cjson ttak pthread dl uriparser stdc++ m z curl)

--- a/tutorials/02-routing-params/CMakeLists.txt
+++ b/tutorials/02-routing-params/CMakeLists.txt
@@ -4,7 +4,7 @@ project(cwist_tut_02 C)
 set(CMAKE_C_STANDARD 11)
 
 include_directories(../../include ../../lib ../../lib/libttak/include)
-link_directories(../../ ../../lib/cjson ../../lib/libttak/lib ../../lib/uriparser/build)
+link_directories(../../ ../../lib/cjson ../../lib/libttak/lib ../../lib/uriparser/build ../../lib/boringssl/build ../../lib/lsquic/build/src/liblsquic ../../lib/cnats/build/lib)
 
 add_executable(tut02 main.c)
-target_link_libraries(tut02 PRIVATE cwist cjson ttak pthread dl uriparser stdc++ m z curl)
+target_link_libraries(tut02 PRIVATE cwist lsquic ssl crypto nats_static cjson ttak pthread dl uriparser stdc++ m z curl)

--- a/tutorials/03-json-api/CMakeLists.txt
+++ b/tutorials/03-json-api/CMakeLists.txt
@@ -4,7 +4,7 @@ project(cwist_tut_03 C)
 set(CMAKE_C_STANDARD 11)
 
 include_directories(../../include ../../lib ../../lib/libttak/include ../../lib/cjson)
-link_directories(../../ ../../lib/cjson ../../lib/libttak/lib ../../lib/uriparser/build)
+link_directories(../../ ../../lib/cjson ../../lib/libttak/lib ../../lib/uriparser/build ../../lib/boringssl/build ../../lib/lsquic/build/src/liblsquic ../../lib/cnats/build/lib)
 
 add_executable(tut03 main.c)
-target_link_libraries(tut03 PRIVATE cwist cjson ttak pthread dl uriparser stdc++ m z curl)
+target_link_libraries(tut03 PRIVATE cwist lsquic ssl crypto nats_static cjson ttak pthread dl uriparser stdc++ m z curl)

--- a/tutorials/04-middleware-pipeline/CMakeLists.txt
+++ b/tutorials/04-middleware-pipeline/CMakeLists.txt
@@ -4,7 +4,7 @@ project(cwist_tut_04 C)
 set(CMAKE_C_STANDARD 11)
 
 include_directories(../../include ../../lib ../../lib/libttak/include)
-link_directories(../../ ../../lib/cjson ../../lib/libttak/lib ../../lib/uriparser/build)
+link_directories(../../ ../../lib/cjson ../../lib/libttak/lib ../../lib/uriparser/build ../../lib/boringssl/build ../../lib/lsquic/build/src/liblsquic ../../lib/cnats/build/lib)
 
 add_executable(tut04 main.c)
-target_link_libraries(tut04 PRIVATE cwist cjson ttak pthread dl uriparser stdc++ m z curl)
+target_link_libraries(tut04 PRIVATE cwist lsquic ssl crypto nats_static cjson ttak pthread dl uriparser stdc++ m z curl)

--- a/tutorials/05-database-sqlite/CMakeLists.txt
+++ b/tutorials/05-database-sqlite/CMakeLists.txt
@@ -4,7 +4,7 @@ project(cwist_tut_05 C)
 set(CMAKE_C_STANDARD 11)
 
 include_directories(../../include ../../lib ../../lib/libttak/include ../../lib/sqlite3 ../../lib/cjson)
-link_directories(../../ ../../lib/cjson ../../lib/libttak/lib ../../lib/uriparser/build)
+link_directories(../../ ../../lib/cjson ../../lib/libttak/lib ../../lib/uriparser/build ../../lib/boringssl/build ../../lib/lsquic/build/src/liblsquic ../../lib/cnats/build/lib)
 
 add_executable(tut05 main.c)
-target_link_libraries(tut05 PRIVATE cwist cjson ttak pthread dl uriparser stdc++ m z curl)
+target_link_libraries(tut05 PRIVATE cwist lsquic ssl crypto nats_static cjson ttak pthread dl uriparser stdc++ m z curl)

--- a/tutorials/06-db-pool/CMakeLists.txt
+++ b/tutorials/06-db-pool/CMakeLists.txt
@@ -4,7 +4,7 @@ project(cwist_tut_06 C)
 set(CMAKE_C_STANDARD 11)
 
 include_directories(../../include ../../lib ../../lib/libttak/include ../../lib/sqlite3 ../../lib/cjson)
-link_directories(../../ ../../lib/cjson ../../lib/libttak/lib ../../lib/uriparser/build)
+link_directories(../../ ../../lib/cjson ../../lib/libttak/lib ../../lib/uriparser/build ../../lib/boringssl/build ../../lib/lsquic/build/src/liblsquic ../../lib/cnats/build/lib)
 
 add_executable(tut06 main.c)
-target_link_libraries(tut06 PRIVATE cwist cjson ttak pthread dl uriparser stdc++ m z curl)
+target_link_libraries(tut06 PRIVATE cwist lsquic ssl crypto nats_static cjson ttak pthread dl uriparser stdc++ m z curl)

--- a/tutorials/07-jwt-auth/CMakeLists.txt
+++ b/tutorials/07-jwt-auth/CMakeLists.txt
@@ -4,7 +4,7 @@ project(cwist_tut_07 C)
 set(CMAKE_C_STANDARD 11)
 
 include_directories(../../include ../../lib ../../lib/libttak/include ../../lib/cjson)
-link_directories(../../ ../../lib/cjson ../../lib/libttak/lib ../../lib/uriparser/build)
+link_directories(../../ ../../lib/cjson ../../lib/libttak/lib ../../lib/uriparser/build ../../lib/boringssl/build ../../lib/lsquic/build/src/liblsquic ../../lib/cnats/build/lib)
 
 add_executable(tut07 main.c)
-target_link_libraries(tut07 PRIVATE cwist cjson ttak pthread dl uriparser stdc++ m z curl)
+target_link_libraries(tut07 PRIVATE cwist lsquic ssl crypto nats_static cjson ttak pthread dl uriparser stdc++ m z curl)

--- a/tutorials/07-jwt-auth/README.md
+++ b/tutorials/07-jwt-auth/README.md
@@ -5,6 +5,12 @@ Sign and verify JWT tokens for stateless API authorization using the built-in CW
 ## Key Concepts
 - Construct token payload claims using `cJSON`.
 - Generate signed JWT string with `cwist_jwt_sign(payload, secret)`.
+- Release the returned token with `CWIST_DEFER_FREE` (`cwist/core/mem/alloc.h`)
+  instead of a manual `free()` call: attach it to the pointer's declaration
+  and it releases automatically on every return path out of the enclosing
+  block. Only safe for a pointer that never escapes that block — `token`
+  here doesn't, since `cwist_sstring_assign()` copies its bytes into the
+  response body rather than taking ownership of the pointer.
 
 ## Build and Run
 

--- a/tutorials/07-jwt-auth/main.c
+++ b/tutorials/07-jwt-auth/main.c
@@ -1,5 +1,6 @@
 #include <cwist/app.h>
 #include <cwist/security/jwt/jwt.h>
+#include <cwist/core/mem/alloc.h>
 
 static void handle_token(cwist_http_request *req, cwist_http_response *res) {
     (void)req;
@@ -9,13 +10,17 @@ static void handle_token(cwist_http_request *req, cwist_http_response *res) {
     cJSON_AddStringToObject(payload, "user", "admin");
 
     char *json_str = cJSON_PrintUnformatted(payload);
-    char *token = cwist_jwt_sign(json_str, secret, 3600);
+    /* CWIST_DEFER_FREE runs cwist_free() on token when this function
+     * returns, on every path -- no separate free(token) to remember (or
+     * forget) below. Only safe because token never escapes this function:
+     * cwist_sstring_assign() copies its bytes into res->body rather than
+     * taking ownership of the pointer. See cwist/core/mem/alloc.h. */
+    char *token CWIST_DEFER_FREE = cwist_jwt_sign(json_str, secret, 3600);
     free(json_str);
     cJSON_Delete(payload);
 
     if (token) {
         cwist_sstring_assign(res->body, token);
-        free(token);
     } else {
         cwist_sstring_assign(res->body, "JWT sign failed");
     }

--- a/tutorials/08-sse-realtime/CMakeLists.txt
+++ b/tutorials/08-sse-realtime/CMakeLists.txt
@@ -4,7 +4,7 @@ project(cwist_tut_08 C)
 set(CMAKE_C_STANDARD 11)
 
 include_directories(../../include ../../lib ../../lib/libttak/include)
-link_directories(../../ ../../lib/cjson ../../lib/libttak/lib ../../lib/uriparser/build)
+link_directories(../../ ../../lib/cjson ../../lib/libttak/lib ../../lib/uriparser/build ../../lib/boringssl/build ../../lib/lsquic/build/src/liblsquic ../../lib/cnats/build/lib)
 
 add_executable(tut08 main.c)
-target_link_libraries(tut08 PRIVATE cwist cjson ttak pthread dl uriparser stdc++ m z curl)
+target_link_libraries(tut08 PRIVATE cwist lsquic ssl crypto nats_static cjson ttak pthread dl uriparser stdc++ m z curl)

--- a/tutorials/09-websocket-chat/CMakeLists.txt
+++ b/tutorials/09-websocket-chat/CMakeLists.txt
@@ -4,7 +4,7 @@ project(cwist_tut_09 C)
 set(CMAKE_C_STANDARD 11)
 
 include_directories(../../include ../../lib ../../lib/libttak/include)
-link_directories(../../ ../../lib/cjson ../../lib/libttak/lib ../../lib/uriparser/build)
+link_directories(../../ ../../lib/cjson ../../lib/libttak/lib ../../lib/uriparser/build ../../lib/boringssl/build ../../lib/lsquic/build/src/liblsquic ../../lib/cnats/build/lib)
 
 add_executable(tut09 main.c)
-target_link_libraries(tut09 PRIVATE cwist cjson ttak pthread dl uriparser stdc++ m z curl)
+target_link_libraries(tut09 PRIVATE cwist lsquic ssl crypto nats_static cjson ttak pthread dl uriparser stdc++ m z curl)

--- a/tutorials/10-background-scheduler/CMakeLists.txt
+++ b/tutorials/10-background-scheduler/CMakeLists.txt
@@ -4,7 +4,7 @@ project(cwist_tut_10 C)
 set(CMAKE_C_STANDARD 11)
 
 include_directories(../../include ../../lib ../../lib/libttak/include)
-link_directories(../../ ../../lib/cjson ../../lib/libttak/lib ../../lib/uriparser/build)
+link_directories(../../ ../../lib/cjson ../../lib/libttak/lib ../../lib/uriparser/build ../../lib/boringssl/build ../../lib/lsquic/build/src/liblsquic ../../lib/cnats/build/lib)
 
 add_executable(tut10 main.c)
-target_link_libraries(tut10 PRIVATE cwist cjson ttak pthread dl uriparser stdc++ m z curl)
+target_link_libraries(tut10 PRIVATE cwist lsquic ssl crypto nats_static cjson ttak pthread dl uriparser stdc++ m z curl)

--- a/tutorials/11-csrf-protection/CMakeLists.txt
+++ b/tutorials/11-csrf-protection/CMakeLists.txt
@@ -4,7 +4,7 @@ project(cwist_tut_11 C)
 set(CMAKE_C_STANDARD 11)
 
 include_directories(../../include ../../lib ../../lib/libttak/include)
-link_directories(../../ ../../lib/cjson ../../lib/libttak/lib ../../lib/uriparser/build)
+link_directories(../../ ../../lib/cjson ../../lib/libttak/lib ../../lib/uriparser/build ../../lib/boringssl/build ../../lib/lsquic/build/src/liblsquic ../../lib/cnats/build/lib)
 
 add_executable(tut11 main.c)
-target_link_libraries(tut11 PRIVATE cwist cjson ttak pthread dl uriparser stdc++ m z curl)
+target_link_libraries(tut11 PRIVATE cwist lsquic ssl crypto nats_static cjson ttak pthread dl uriparser stdc++ m z curl)

--- a/tutorials/12-cookie-session/CMakeLists.txt
+++ b/tutorials/12-cookie-session/CMakeLists.txt
@@ -4,7 +4,7 @@ project(cwist_tut_12 C)
 set(CMAKE_C_STANDARD 11)
 
 include_directories(../../include ../../lib ../../lib/libttak/include)
-link_directories(../../ ../../lib/cjson ../../lib/libttak/lib ../../lib/uriparser/build)
+link_directories(../../ ../../lib/cjson ../../lib/libttak/lib ../../lib/uriparser/build ../../lib/boringssl/build ../../lib/lsquic/build/src/liblsquic ../../lib/cnats/build/lib)
 
 add_executable(tut12 main.c)
-target_link_libraries(tut12 PRIVATE cwist cjson ttak pthread dl uriparser stdc++ m z curl)
+target_link_libraries(tut12 PRIVATE cwist lsquic ssl crypto nats_static cjson ttak pthread dl uriparser stdc++ m z curl)

--- a/tutorials/13-compression-gzip-zstd/CMakeLists.txt
+++ b/tutorials/13-compression-gzip-zstd/CMakeLists.txt
@@ -4,7 +4,7 @@ project(cwist_tut_13 C)
 set(CMAKE_C_STANDARD 11)
 
 include_directories(../../include ../../lib ../../lib/libttak/include)
-link_directories(../../ ../../lib/cjson ../../lib/libttak/lib ../../lib/uriparser/build)
+link_directories(../../ ../../lib/cjson ../../lib/libttak/lib ../../lib/uriparser/build ../../lib/boringssl/build ../../lib/lsquic/build/src/liblsquic ../../lib/cnats/build/lib)
 
 add_executable(tut13 main.c)
-target_link_libraries(tut13 PRIVATE cwist cjson ttak pthread dl uriparser stdc++ m z zstd brotlienc brotlicommon brotlidec curl)
+target_link_libraries(tut13 PRIVATE cwist lsquic ssl crypto nats_static cjson ttak pthread dl uriparser stdc++ m z zstd brotlienc brotlicommon brotlidec curl)

--- a/tutorials/14-metrics-observability/CMakeLists.txt
+++ b/tutorials/14-metrics-observability/CMakeLists.txt
@@ -4,7 +4,7 @@ project(cwist_tut_14 C)
 set(CMAKE_C_STANDARD 11)
 
 include_directories(../../include ../../lib ../../lib/libttak/include)
-link_directories(../../ ../../lib/cjson ../../lib/libttak/lib ../../lib/uriparser/build)
+link_directories(../../ ../../lib/cjson ../../lib/libttak/lib ../../lib/uriparser/build ../../lib/boringssl/build ../../lib/lsquic/build/src/liblsquic ../../lib/cnats/build/lib)
 
 add_executable(tut14 main.c)
-target_link_libraries(tut14 PRIVATE cwist cjson ttak pthread dl uriparser stdc++ m z curl)
+target_link_libraries(tut14 PRIVATE cwist lsquic ssl crypto nats_static cjson ttak pthread dl uriparser stdc++ m z curl)

--- a/tutorials/15-multipart-upload/CMakeLists.txt
+++ b/tutorials/15-multipart-upload/CMakeLists.txt
@@ -4,7 +4,7 @@ project(cwist_tut_15 C)
 set(CMAKE_C_STANDARD 11)
 
 include_directories(../../include ../../lib ../../lib/libttak/include)
-link_directories(../../ ../../lib/cjson ../../lib/libttak/lib ../../lib/uriparser/build)
+link_directories(../../ ../../lib/cjson ../../lib/libttak/lib ../../lib/uriparser/build ../../lib/boringssl/build ../../lib/lsquic/build/src/liblsquic ../../lib/cnats/build/lib)
 
 add_executable(tut15 main.c)
-target_link_libraries(tut15 PRIVATE cwist cjson ttak pthread dl uriparser stdc++ m z curl)
+target_link_libraries(tut15 PRIVATE cwist lsquic ssl crypto nats_static cjson ttak pthread dl uriparser stdc++ m z curl)

--- a/tutorials/16-html-builder/CMakeLists.txt
+++ b/tutorials/16-html-builder/CMakeLists.txt
@@ -4,7 +4,7 @@ project(cwist_tut_16 C)
 set(CMAKE_C_STANDARD 11)
 
 include_directories(../../include ../../lib ../../lib/libttak/include)
-link_directories(../../ ../../lib/cjson ../../lib/libttak/lib ../../lib/uriparser/build)
+link_directories(../../ ../../lib/cjson ../../lib/libttak/lib ../../lib/uriparser/build ../../lib/boringssl/build ../../lib/lsquic/build/src/liblsquic ../../lib/cnats/build/lib)
 
 add_executable(tut16 main.c)
-target_link_libraries(tut16 PRIVATE cwist cjson ttak pthread dl uriparser stdc++ m z curl)
+target_link_libraries(tut16 PRIVATE cwist lsquic ssl crypto nats_static cjson ttak pthread dl uriparser stdc++ m z curl)

--- a/tutorials/17-css-composer/CMakeLists.txt
+++ b/tutorials/17-css-composer/CMakeLists.txt
@@ -4,7 +4,7 @@ project(cwist_tut_17 C)
 set(CMAKE_C_STANDARD 11)
 
 include_directories(../../include ../../lib ../../lib/libttak/include)
-link_directories(../../ ../../lib/cjson ../../lib/libttak/lib ../../lib/uriparser/build)
+link_directories(../../ ../../lib/cjson ../../lib/libttak/lib ../../lib/uriparser/build ../../lib/boringssl/build ../../lib/lsquic/build/src/liblsquic ../../lib/cnats/build/lib)
 
 add_executable(tut17 main.c)
-target_link_libraries(tut17 PRIVATE cwist cjson ttak pthread dl uriparser stdc++ m z curl)
+target_link_libraries(tut17 PRIVATE cwist lsquic ssl crypto nats_static cjson ttak pthread dl uriparser stdc++ m z curl)

--- a/tutorials/18-healthz-check/CMakeLists.txt
+++ b/tutorials/18-healthz-check/CMakeLists.txt
@@ -4,7 +4,7 @@ project(cwist_tut_18 C)
 set(CMAKE_C_STANDARD 11)
 
 include_directories(../../include ../../lib ../../lib/libttak/include)
-link_directories(../../ ../../lib/cjson ../../lib/libttak/lib ../../lib/uriparser/build)
+link_directories(../../ ../../lib/cjson ../../lib/libttak/lib ../../lib/uriparser/build ../../lib/boringssl/build ../../lib/lsquic/build/src/liblsquic ../../lib/cnats/build/lib)
 
 add_executable(tut18 main.c)
-target_link_libraries(tut18 PRIVATE cwist cjson ttak pthread dl uriparser stdc++ m z curl)
+target_link_libraries(tut18 PRIVATE cwist lsquic ssl crypto nats_static cjson ttak pthread dl uriparser stdc++ m z curl)

--- a/tutorials/19-post-quantum-tls/CMakeLists.txt
+++ b/tutorials/19-post-quantum-tls/CMakeLists.txt
@@ -4,7 +4,7 @@ project(cwist_tut_19 C)
 set(CMAKE_C_STANDARD 11)
 
 include_directories(../../include ../../lib ../../lib/libttak/include)
-link_directories(../../ ../../lib/cjson ../../lib/libttak/lib ../../lib/uriparser/build)
+link_directories(../../ ../../lib/cjson ../../lib/libttak/lib ../../lib/uriparser/build ../../lib/boringssl/build ../../lib/lsquic/build/src/liblsquic ../../lib/cnats/build/lib)
 
 add_executable(tut19 main.c)
-target_link_libraries(tut19 PRIVATE cwist cjson ttak pthread dl uriparser stdc++ m z curl)
+target_link_libraries(tut19 PRIVATE cwist lsquic ssl crypto nats_static cjson ttak pthread dl uriparser stdc++ m z curl)

--- a/tutorials/20-http3-quic-server/CMakeLists.txt
+++ b/tutorials/20-http3-quic-server/CMakeLists.txt
@@ -4,7 +4,7 @@ project(cwist_tut_20 C)
 set(CMAKE_C_STANDARD 11)
 
 include_directories(../../include ../../lib ../../lib/libttak/include)
-link_directories(../../ ../../lib/cjson ../../lib/libttak/lib ../../lib/uriparser/build)
+link_directories(../../ ../../lib/cjson ../../lib/libttak/lib ../../lib/uriparser/build ../../lib/boringssl/build ../../lib/lsquic/build/src/liblsquic ../../lib/cnats/build/lib)
 
 add_executable(tut20 main.c)
-target_link_libraries(tut20 PRIVATE cwist cjson ttak pthread dl uriparser stdc++ m z curl)
+target_link_libraries(tut20 PRIVATE cwist lsquic ssl crypto nats_static cjson ttak pthread dl uriparser stdc++ m z curl)

--- a/tutorials/21-waf-security/CMakeLists.txt
+++ b/tutorials/21-waf-security/CMakeLists.txt
@@ -4,7 +4,7 @@ project(cwist_tut_21 C)
 set(CMAKE_C_STANDARD 11)
 
 include_directories(../../include ../../lib ../../lib/libttak/include)
-link_directories(../../ ../../lib/cjson ../../lib/libttak/lib ../../lib/uriparser/build)
+link_directories(../../ ../../lib/cjson ../../lib/libttak/lib ../../lib/uriparser/build ../../lib/boringssl/build ../../lib/lsquic/build/src/liblsquic ../../lib/cnats/build/lib)
 
 add_executable(tut21 main.c)
-target_link_libraries(tut21 PRIVATE cwist cjson ttak pthread dl uriparser stdc++ m z curl)
+target_link_libraries(tut21 PRIVATE cwist lsquic ssl crypto nats_static cjson ttak pthread dl uriparser stdc++ m z curl)

--- a/tutorials/22-rate-limiting/CMakeLists.txt
+++ b/tutorials/22-rate-limiting/CMakeLists.txt
@@ -4,7 +4,7 @@ project(cwist_tut_22 C)
 set(CMAKE_C_STANDARD 11)
 
 include_directories(../../include ../../lib ../../lib/libttak/include)
-link_directories(../../ ../../lib/cjson ../../lib/libttak/lib ../../lib/uriparser/build)
+link_directories(../../ ../../lib/cjson ../../lib/libttak/lib ../../lib/uriparser/build ../../lib/boringssl/build ../../lib/lsquic/build/src/liblsquic ../../lib/cnats/build/lib)
 
 add_executable(tut22 main.c)
-target_link_libraries(tut22 PRIVATE cwist cjson ttak pthread dl uriparser stdc++ m z curl)
+target_link_libraries(tut22 PRIVATE cwist lsquic ssl crypto nats_static cjson ttak pthread dl uriparser stdc++ m z curl)

--- a/tutorials/23-cors-policy/CMakeLists.txt
+++ b/tutorials/23-cors-policy/CMakeLists.txt
@@ -4,7 +4,7 @@ project(cwist_tut_23 C)
 set(CMAKE_C_STANDARD 11)
 
 include_directories(../../include ../../lib ../../lib/libttak/include)
-link_directories(../../ ../../lib/cjson ../../lib/libttak/lib ../../lib/uriparser/build)
+link_directories(../../ ../../lib/cjson ../../lib/libttak/lib ../../lib/uriparser/build ../../lib/boringssl/build ../../lib/lsquic/build/src/liblsquic ../../lib/cnats/build/lib)
 
 add_executable(tut23 main.c)
-target_link_libraries(tut23 PRIVATE cwist cjson ttak pthread dl uriparser stdc++ m z curl)
+target_link_libraries(tut23 PRIVATE cwist lsquic ssl crypto nats_static cjson ttak pthread dl uriparser stdc++ m z curl)

--- a/tutorials/24-secure-headers/CMakeLists.txt
+++ b/tutorials/24-secure-headers/CMakeLists.txt
@@ -4,7 +4,7 @@ project(cwist_tut_24 C)
 set(CMAKE_C_STANDARD 11)
 
 include_directories(../../include ../../lib ../../lib/libttak/include)
-link_directories(../../ ../../lib/cjson ../../lib/libttak/lib ../../lib/uriparser/build)
+link_directories(../../ ../../lib/cjson ../../lib/libttak/lib ../../lib/uriparser/build ../../lib/boringssl/build ../../lib/lsquic/build/src/liblsquic ../../lib/cnats/build/lib)
 
 add_executable(tut24 main.c)
-target_link_libraries(tut24 PRIVATE cwist cjson ttak pthread dl uriparser stdc++ m z curl)
+target_link_libraries(tut24 PRIVATE cwist lsquic ssl crypto nats_static cjson ttak pthread dl uriparser stdc++ m z curl)

--- a/tutorials/25-big-dumb-reply-cache/CMakeLists.txt
+++ b/tutorials/25-big-dumb-reply-cache/CMakeLists.txt
@@ -4,7 +4,7 @@ project(cwist_tut_25 C)
 set(CMAKE_C_STANDARD 11)
 
 include_directories(../../include ../../lib ../../lib/libttak/include)
-link_directories(../../ ../../lib/cjson ../../lib/libttak/lib ../../lib/uriparser/build)
+link_directories(../../ ../../lib/cjson ../../lib/libttak/lib ../../lib/uriparser/build ../../lib/boringssl/build ../../lib/lsquic/build/src/liblsquic ../../lib/cnats/build/lib)
 
 add_executable(tut25 main.c)
-target_link_libraries(tut25 PRIVATE cwist cjson ttak pthread dl uriparser stdc++ m z curl)
+target_link_libraries(tut25 PRIVATE cwist lsquic ssl crypto nats_static cjson ttak pthread dl uriparser stdc++ m z curl)

--- a/tutorials/26-generic-orm/CMakeLists.txt
+++ b/tutorials/26-generic-orm/CMakeLists.txt
@@ -4,7 +4,7 @@ project(cwist_tut_26 C)
 set(CMAKE_C_STANDARD 11)
 
 include_directories(../../include ../../lib ../../lib/libttak/include)
-link_directories(../../ ../../lib/cjson ../../lib/libttak/lib ../../lib/uriparser/build)
+link_directories(../../ ../../lib/cjson ../../lib/libttak/lib ../../lib/uriparser/build ../../lib/boringssl/build ../../lib/lsquic/build/src/liblsquic ../../lib/cnats/build/lib)
 
 add_executable(tut26 main.c)
-target_link_libraries(tut26 PRIVATE cwist cjson ttak pthread dl uriparser stdc++ m z curl)
+target_link_libraries(tut26 PRIVATE cwist lsquic ssl crypto nats_static cjson ttak pthread dl uriparser stdc++ m z curl)

--- a/tutorials/27-db-migrations/CMakeLists.txt
+++ b/tutorials/27-db-migrations/CMakeLists.txt
@@ -4,7 +4,7 @@ project(cwist_tut_27 C)
 set(CMAKE_C_STANDARD 11)
 
 include_directories(../../include ../../lib ../../lib/libttak/include)
-link_directories(../../ ../../lib/cjson ../../lib/libttak/lib ../../lib/uriparser/build)
+link_directories(../../ ../../lib/cjson ../../lib/libttak/lib ../../lib/uriparser/build ../../lib/boringssl/build ../../lib/lsquic/build/src/liblsquic ../../lib/cnats/build/lib)
 
 add_executable(tut27 main.c)
-target_link_libraries(tut27 PRIVATE cwist cjson ttak pthread dl uriparser stdc++ m z curl)
+target_link_libraries(tut27 PRIVATE cwist lsquic ssl crypto nats_static cjson ttak pthread dl uriparser stdc++ m z curl)

--- a/tutorials/28-transparent-column-encryption/CMakeLists.txt
+++ b/tutorials/28-transparent-column-encryption/CMakeLists.txt
@@ -4,7 +4,7 @@ project(cwist_tut_28 C)
 set(CMAKE_C_STANDARD 11)
 
 include_directories(../../include ../../lib ../../lib/libttak/include)
-link_directories(../../ ../../lib/cjson ../../lib/libttak/lib ../../lib/uriparser/build)
+link_directories(../../ ../../lib/cjson ../../lib/libttak/lib ../../lib/uriparser/build ../../lib/boringssl/build ../../lib/lsquic/build/src/liblsquic ../../lib/cnats/build/lib)
 
 add_executable(tut28 main.c)
-target_link_libraries(tut28 PRIVATE cwist cjson ttak pthread dl uriparser stdc++ m z curl)
+target_link_libraries(tut28 PRIVATE cwist lsquic ssl crypto nats_static cjson ttak pthread dl uriparser stdc++ m z curl)

--- a/tutorials/28-transparent-column-encryption/README.md
+++ b/tutorials/28-transparent-column-encryption/README.md
@@ -4,6 +4,11 @@ Encrypt and decrypt sensitive database fields transparently at column boundaries
 
 ## Key Concepts
 - Automatic AES/ChaCha20 field encryption for compliance and data privacy.
+- `sealed`/`opened` are released via `CWIST_DEFER_FREE` rather than manual
+  `free()` calls — since both stay local to `main()`, attaching the macro to
+  each declaration releases it automatically at the end of whichever block
+  it was declared in (see `cwist/core/mem/alloc.h`), instead of a `free()`
+  that has to be kept paired with every return path by hand.
 
 ## Build and Run
 

--- a/tutorials/28-transparent-column-encryption/main.c
+++ b/tutorials/28-transparent-column-encryption/main.c
@@ -1,5 +1,6 @@
 #include <cwist/app.h>
 #include <cwist/security/db_crypt/db_crypt.h>
+#include <cwist/core/mem/alloc.h>
 
 int main(void) {
     cwist_db_crypt_ctx_t ctx;
@@ -7,17 +8,19 @@ int main(void) {
 
     const char *plaintext = "SQLite format 3\0Sensitive DB Content";
     size_t sealed_len = 0;
-    unsigned char *sealed = cwist_db_crypt_seal(&ctx, (const unsigned char *)plaintext, strlen(plaintext), &sealed_len);
+    /* CWIST_DEFER_FREE: sealed/opened never leave main(), so each is
+     * released automatically at the end of the block it was declared in
+     * (opened at the inner if's close, sealed at the outer one) instead of
+     * an explicit free() to keep matched with every return path. */
+    unsigned char *sealed CWIST_DEFER_FREE = cwist_db_crypt_seal(&ctx, (const unsigned char *)plaintext, strlen(plaintext), &sealed_len);
     if (sealed) {
         printf("Sealed DB blob created (%zu bytes)\n", sealed_len);
 
         size_t opened_len = 0;
-        unsigned char *opened = cwist_db_crypt_open(&ctx, sealed, sealed_len, &opened_len);
+        unsigned char *opened CWIST_DEFER_FREE = cwist_db_crypt_open(&ctx, sealed, sealed_len, &opened_len);
         if (opened) {
             printf("Opened DB blob successfully (%zu bytes)\n", opened_len);
-            free(opened);
         }
-        free(sealed);
     }
     return 0;
 }

--- a/tutorials/29-test-client-automation/CMakeLists.txt
+++ b/tutorials/29-test-client-automation/CMakeLists.txt
@@ -4,7 +4,7 @@ project(cwist_tut_29 C)
 set(CMAKE_C_STANDARD 11)
 
 include_directories(../../include ../../lib ../../lib/libttak/include)
-link_directories(../../ ../../lib/cjson ../../lib/libttak/lib ../../lib/uriparser/build)
+link_directories(../../ ../../lib/cjson ../../lib/libttak/lib ../../lib/uriparser/build ../../lib/boringssl/build ../../lib/lsquic/build/src/liblsquic ../../lib/cnats/build/lib)
 
 add_executable(tut29 main.c)
-target_link_libraries(tut29 PRIVATE cwist cjson ttak pthread dl uriparser stdc++ m z curl)
+target_link_libraries(tut29 PRIVATE cwist lsquic ssl crypto nats_static cjson ttak pthread dl uriparser stdc++ m z curl)

--- a/tutorials/30-graceful-shutdown/CMakeLists.txt
+++ b/tutorials/30-graceful-shutdown/CMakeLists.txt
@@ -4,7 +4,7 @@ project(cwist_tut_30 C)
 set(CMAKE_C_STANDARD 11)
 
 include_directories(../../include ../../lib ../../lib/libttak/include)
-link_directories(../../ ../../lib/cjson ../../lib/libttak/lib ../../lib/uriparser/build)
+link_directories(../../ ../../lib/cjson ../../lib/libttak/lib ../../lib/uriparser/build ../../lib/boringssl/build ../../lib/lsquic/build/src/liblsquic ../../lib/cnats/build/lib)
 
 add_executable(tut30 main.c)
-target_link_libraries(tut30 PRIVATE cwist cjson ttak pthread dl uriparser stdc++ m z curl)
+target_link_libraries(tut30 PRIVATE cwist lsquic ssl crypto nats_static cjson ttak pthread dl uriparser stdc++ m z curl)

--- a/tutorials/30-graceful-shutdown/README.md
+++ b/tutorials/30-graceful-shutdown/README.md
@@ -4,6 +4,16 @@ Catch system termination signals (`SIGTERM`, `SIGINT`) to drain active connectio
 
 ## Key Concepts
 - Registering signal handlers and initiating graceful teardown.
+- `cwist_full_gc(true)` (`cwist/core/mem/gc.h`) as the automatic half of
+  graceful shutdown: a worker thread or process that ends without running
+  the explicit `cwist_app_destroy()` path still gets its connections closed
+  and its `cwist_alloc()` blocks reclaimed (per-thread TLS sweep on thread
+  exit, `atexit` sweep on process exit). It's a one-shot, process-wide
+  toggle — first call wins, every later call is a no-op — and it's off by
+  default, so the explicit model runs unchanged at zero cost if you never
+  call it. Call it alongside `cwist_app_destroy()`, not instead of it: the
+  explicit path stays the deterministic primary shutdown, full-GC is the
+  safety net for the paths that skip it. See `docs/GC.md`.
 
 ## Build and Run
 

--- a/tutorials/30-graceful-shutdown/main.c
+++ b/tutorials/30-graceful-shutdown/main.c
@@ -1,4 +1,5 @@
 #include <cwist/app.h>
+#include <cwist/core/mem/gc.h>
 
 static void handle_home(cwist_http_request *req, cwist_http_response *res) {
     (void)req;
@@ -6,6 +7,22 @@ static void handle_home(cwist_http_request *req, cwist_http_response *res) {
 }
 
 int main(void) {
+    /* cwist_full_gc(true): the automatic half of graceful shutdown. A
+     * worker thread that exits (or a process that ends) without running
+     * the explicit cwist_app_destroy() path below still gets its
+     * connections closed and its cwist_alloc() blocks reclaimed -- a TLS
+     * destructor sweeps per-thread on thread exit, and an atexit hook
+     * sweeps whatever is left on process exit. This is a one-shot,
+     * process-wide toggle (first call wins, every later call is a no-op)
+     * and it is off by default: the explicit model below runs unchanged
+     * at zero cost if you never call this. See docs/GC.md.
+     *
+     * It complements cwist_app_destroy(), it does not replace it: call
+     * both, same as here. The explicit path stays the primary, deterministic
+     * shutdown; full-GC is the safety net for the paths that skip it (a
+     * worker thread that panics, a signal handler that exits early, ...). */
+    cwist_full_gc(true);
+
     cwist_app *app = cwist_app_create();
     cwist_app_get(app, "/", handle_home);
     printf("Starting server. Send SIGTERM/SIGINT to initiate graceful shutdown.\n");

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -12,7 +12,7 @@ Welcome to the **CWIST** hands-on tutorial series. Each directory contains a run
 4. **[04-middleware-pipeline](04-middleware-pipeline)**: Pipeline middleware registration (`cwist_app_use`) for global logging and request processing.
 5. **[05-database-sqlite](05-database-sqlite)**: Embedded in-memory SQLite integration, schema creation, and querying.
 6. **[06-db-pool](06-db-pool)**: High-concurrency thread-safe SQLite connection pool (`cwist_db_pool_t`) management.
-7. **[07-jwt-auth](07-jwt-auth)**: Issuing and signing JSON Web Tokens (`cwist_jwt_sign`) for stateless authentication.
+7. **[07-jwt-auth](07-jwt-auth)**: Issuing and signing JSON Web Tokens (`cwist_jwt_sign`) for stateless authentication, releasing the returned token with `CWIST_DEFER_FREE`.
 8. **[08-sse-realtime](08-sse-realtime)**: Unidirectional real-time event streaming with Server-Sent Events (SSE).
 9. **[09-websocket-chat](09-websocket-chat)**: Full-duplex bidirectional communication with WebSocket handlers.
 10. **[10-background-scheduler](10-background-scheduler)**: Asynchronous task execution with worker thread background schedulers.
@@ -33,9 +33,33 @@ Welcome to the **CWIST** hands-on tutorial series. Each directory contains a run
 25. **[25-big-dumb-reply-cache](25-big-dumb-reply-cache)**: Ultra-fast static response caching with the Big Dumb Reply (BDR) engine.
 26. **[26-generic-orm](26-generic-orm)**: Type-safe generic ORM query building via C11 `_Generic` macros.
 27. **[27-db-migrations](27-db-migrations)**: Programmatic database schema migration execution.
-28. **[28-transparent-column-encryption](28-transparent-column-encryption)**: Transparent column-level database encryption (`db_crypt`).
+28. **[28-transparent-column-encryption](28-transparent-column-encryption)**: Transparent column-level database encryption (`db_crypt`), with sealed/opened buffers released via `CWIST_DEFER_FREE`.
 29. **[29-test-client-automation](29-test-client-automation)**: Writing automated in-memory integration tests with `cwist_test_client`.
-30. **[30-graceful-shutdown](30-graceful-shutdown)**: Handling SIGTERM/SIGINT signals for graceful server shutdown.
+30. **[30-graceful-shutdown](30-graceful-shutdown)**: Handling SIGTERM/SIGINT signals for graceful server shutdown, plus `cwist_full_gc(true)` as its automatic complement.
+
+---
+
+## Memory management: DEFER macros and full-GC auto-rotate
+
+Two ergonomics layers on top of the explicit `cwist_alloc`/`cwist_free` model
+sit behind this series — most tutorials don't need either (see
+[docs/GC.md](../docs/GC.md) and `cwist/core/mem/alloc.h` for the full
+picture), but two demonstrate them directly:
+
+- **`CWIST_DEFER_FREE`** (a scoped, block-exit cleanup attached to a
+  pointer's declaration — C's practical equivalent of RAII for a value that
+  never leaves the block it's declared in): [07-jwt-auth](07-jwt-auth) and
+  [28-transparent-column-encryption](28-transparent-column-encryption).
+- **`cwist_full_gc(true)`** (the "auto-rotate" toggle: connections and
+  `cwist_alloc` blocks a thread/process forgets to release explicitly get
+  swept automatically on thread/process exit, epoch-deferred so a swept
+  connection can never be use-after-freed by a thread still on it):
+  [30-graceful-shutdown](30-graceful-shutdown).
+
+Both are opt-in and additive — none of the other 27 tutorials' explicit
+`cwist_free()`/`cwist_app_destroy()` calls need to change, and won't behave
+any differently, whether or not these are used elsewhere in the same
+process.
 
 ---
 


### PR DESCRIPTION
Cherry-pick only the last 7 actual change commits from `dev` into `main` (excluding major unmerged changes such as webtransport/http3_client):

* experiment(alloc): cap glibc arena count per worker (CWIST_MALLOC_ARENA_MAX)
* docs(tutorials): DEFER macros + full-GC auto-rotate examples; fix stale link deps
* fix(reactor): restore io_uring input polling for posted work
* fix(http): grow classic pool for queued connection demand
* test(http): cover pool bursts, concurrent caps and spawn failure
* docs(perf): record pool regression and benchmark limits
* fix(sstring): synchronize string size and detach borrowed buffers in rtrim and ltrim

Manually resolved one conflict in `TEST_TARGETS` within the Makefile (kept test targets added by both sides).