### PR TITLE
chore: cherry-pick 4 dev commits dropped by PR #46's stale commit-count cutoff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -486,6 +486,7 @@ TEST_TARGETS = test_reactor_wake \
                test_static_and_range \
                test_session \
                test_csrf \
+               test_cookie \
                test_waf \
                test_db_pool \
                test_db_memory \
@@ -894,6 +895,10 @@ test_session: $(LIB_NAME) tests/test_session.c
 test_csrf: $(LIB_NAME) tests/test_csrf.c
 	$(CC) $(CFLAGS) -o test_csrf tests/test_csrf.c $(LIB_NAME) $(LIBS)
 	./test_csrf
+
+test_cookie: $(LIB_NAME) tests/test_cookie.c
+	$(CC) $(CFLAGS) -o test_cookie tests/test_cookie.c $(LIB_NAME) $(LIBS)
+	./test_cookie
 
 test_waf: $(LIB_NAME) tests/test_waf.c
 	$(CC) $(CFLAGS) -o test_waf tests/test_waf.c $(LIB_NAME) $(LIBS)

--- a/README.md
+++ b/README.md
@@ -403,6 +403,8 @@ These variables are read directly by the framework runtime (no prefix required):
 |----------|------|---------|-------------|
 | `CWIST_WORKERS` | integer | `1` | Number of worker processes to fork before entering the event loop. |
 | `CWIST_C1M_MODE` | boolean | `true` | Enables the high-concurrency C1M async server loop. Set to `0` or `false` to fall back to a blocking accept loop. |
+| `CWIST_HTTP_BATCH` | integer | `16` | Maximum pipelined HTTP/1.1 requests dispatched per event-loop turn (clamped to `[1, 1024]`). Excess requests are deferred via reactor continuations. |
+| `CWIST_HTTP_YIELD_BATCH` | integer | `16` (derived from batch) | Request dispatch yield granularity within a batch before re-posting connection to reactor queue. |
 | `CWIST_ASYNC_DEBUG` | boolean | unset | When set, the C1M async path and the reactor log rare failure events (rearm/submit/SQ failures) to stderr. No output in normal operation. |
 
 **C1M mode is now measured, not theoretical.** With the event-driven one-shot

--- a/docs/api/http.md
+++ b/docs/api/http.md
@@ -103,3 +103,9 @@ Starts the main server loop.
 cwist_error_t cwist_accept_socket(int server_fd, struct sockaddr *sockv4, void (*handler_func)(int, void *), void *ctx);
 ```
 Low-level accept loop wrapper.
+
+### `cwist_http_continuation_shed_count`
+```c
+long cwist_http_continuation_shed_count(void);
+```
+Monotonic counter of pipelined HTTP/1.1 continuations dropped (and whose connections were closed) because the reactor post queue was full. Also exposed via Prometheus `/metrics` as `cwist_http_continuation_shed_total`. Useful for backpressure and shed-rate alerting.

--- a/include/cwist/sys/metrics/metrics.h
+++ b/include/cwist/sys/metrics/metrics.h
@@ -59,6 +59,7 @@ typedef enum cwist_metric_id {
     CWIST_METRIC_REQUEST_DURATION_NS,     /**< Request duration (nanoseconds sum). */
     CWIST_METRIC_HTTP_HEADER_OVERFLOW,    /**< H1 connections dropped: headers exceeded read buffer. */
     CWIST_METRIC_H2_HEADERS_DROPPED,      /**< H2 header fields dropped: unresolvable HPACK index. */
+    CWIST_METRIC_HTTP_CONTINUATION_SHED,  /**< Pipelined continuations dropped due to full reactor queue. */
     CWIST_METRIC_COUNT
 } cwist_metric_id_t;
 

--- a/src/core/seq/seq.c
+++ b/src/core/seq/seq.c
@@ -150,10 +150,12 @@ void cwist_seq_assembler_destroy(cwist_seq_assembler_t *a) {
 
 void cwist_seq_assembler_reset(cwist_seq_assembler_t *a) {
     if (!a) return;
+    size_t max_data_len = a->max_data_len;
     cwist_free(a->data);
     cwist_free(a->received);
     cwist_free(a->payload_lens);
     memset(a, 0, sizeof(*a));
+    a->max_data_len = max_data_len;
 }
 
 bool cwist_seq_assembler_feed(cwist_seq_assembler_t *a, const cwist_seq_chunk_t *chunk) {

--- a/src/core/utils/json_heal.c
+++ b/src/core/utils/json_heal.c
@@ -79,8 +79,25 @@ static void log_append(char *log, size_t log_sz, const char *msg) {
 static void remove_trailing_commas(strbuf_t *b) {
     char  *d   = b->data;
     size_t len = b->len;
-    for (size_t i = 1; i < len; i++) {
-        if (d[i] == ']' || d[i] == '}') {
+    bool in_str = false;
+    bool esc = false;
+    for (size_t i = 0; i < len; i++) {
+        char c = d[i];
+        if (esc) {
+            esc = false;
+            continue;
+        }
+        if (c == '\\' && in_str) {
+            esc = true;
+            continue;
+        }
+        if (c == '"') {
+            in_str = !in_str;
+            continue;
+        }
+        if (in_str) continue;
+
+        if (c == ']' || c == '}') {
             /* find last non-whitespace before i */
             size_t j = i;
             while (j > 0 && (d[j-1] == ' ' || d[j-1] == '\t' ||

--- a/src/net/http/cookie.c
+++ b/src/net/http/cookie.c
@@ -47,7 +47,9 @@ int cwist_cookie_decode(const char *in, char *out, size_t out_len) {
     size_t j = 0;
     for (size_t i = 0; i < len; i++) {
         if (j >= out_len - 1) return -1;
-        if (in[i] == '%' && i + 2 < len) {
+        if (in[i] == '%' && i + 2 < len &&
+            isxdigit((unsigned char)in[i + 1]) &&
+            isxdigit((unsigned char)in[i + 2])) {
             unsigned int hex;
             if (sscanf(in + i + 1, "%2x", &hex) != 1) {
                 out[j++] = in[i];
@@ -82,12 +84,16 @@ void cwist_cookie_parse(cwist_query_map *map, const char *header) {
             char *name = pair;
             char *value = eq + 1;
             /* trim trailing whitespace on name */
-            char *end = name + strlen(name) - 1;
-            while (end > name && (*end == ' ' || *end == '\t')) *end-- = '\0';
+            size_t nlen = strlen(name);
+            while (nlen > 0 && (name[nlen - 1] == ' ' || name[nlen - 1] == '\t')) {
+                name[--nlen] = '\0';
+            }
 
-            char decoded[4096];
-            if (cwist_cookie_decode(value, decoded, sizeof(decoded)) >= 0) {
-                cwist_query_map_set(map, name, decoded);
+            if (nlen > 0) {
+                char decoded[4096];
+                if (cwist_cookie_decode(value, decoded, sizeof(decoded)) >= 0) {
+                    cwist_query_map_set(map, name, decoded);
+                }
             }
         }
         pair = strtok_r(NULL, ";", &save);

--- a/src/net/http/http.c
+++ b/src/net/http/http.c
@@ -667,6 +667,7 @@ bool cwist_http_async_rearm(int client_fd, cwist_reactor_t *reactor, cwist_http_
         if (!cwist_reactor_post(reactor, &continuation->post)) {
             long n = atomic_fetch_add_explicit(&g_http_continuation_shed, 1,
                                                memory_order_relaxed) + 1;
+            cwist_metric_inc(cwist_metrics_registry(), CWIST_METRIC_HTTP_CONTINUATION_SHED);
             if (getenv("CWIST_ASYNC_DEBUG") && (n <= 5 || n % 10000 == 0))
                 fprintf(stderr, "[async] continuation shed fd=%d total=%ld\n",
                         client_fd, n);

--- a/src/sys/metrics/metrics.c
+++ b/src/sys/metrics/metrics.c
@@ -31,6 +31,7 @@ static const cwist_metric_t metric_defaults[CWIST_METRIC_COUNT] = {
     [CWIST_METRIC_REQUEST_DURATION_NS]  = { .name = "cwist_request_duration_ns",     .help = "Request duration sum in nanoseconds",              .type = CWIST_METRIC_COUNTER },
     [CWIST_METRIC_HTTP_HEADER_OVERFLOW] = { .name = "cwist_http_header_overflow_total", .help = "HTTP/1.1 connections dropped because headers exceeded the read buffer", .type = CWIST_METRIC_COUNTER },
     [CWIST_METRIC_H2_HEADERS_DROPPED]   = { .name = "cwist_h2_headers_dropped_total",   .help = "HTTP/2 header fields dropped due to unresolvable HPACK index",          .type = CWIST_METRIC_COUNTER },
+    [CWIST_METRIC_HTTP_CONTINUATION_SHED] = { .name = "cwist_http_continuation_shed_total", .help = "Pipelined HTTP/1.1 continuations dropped due to full reactor queue", .type = CWIST_METRIC_COUNTER },
 };
 
 /* -------------------------------------------------------------------------
@@ -94,6 +95,9 @@ void cwist_metric_observe(cwist_metrics_registry_t *reg, cwist_metric_id_t id, l
 
 uintmax_t cwist_metric_load(const cwist_metrics_registry_t *reg, cwist_metric_id_t id) {
     if (!reg || id < 0 || id >= CWIST_METRIC_COUNT) return 0;
+    if (id == CWIST_METRIC_HTTP_CONTINUATION_SHED) {
+        return (uintmax_t)cwist_http_continuation_shed_count();
+    }
     return atomic_load_explicit(&reg->metrics[id].value.raw, memory_order_acquire);
 }
 
@@ -112,6 +116,13 @@ static const char *type_str(cwist_metric_type_t t) {
 
 char *cwist_metrics_render_prometheus(const cwist_metrics_registry_t *reg) {
     if (!reg) return NULL;
+
+    /* Synchronize read-only shed counter from net/http */
+    long shed = cwist_http_continuation_shed_count();
+    atomic_store_explicit(&((cwist_metrics_registry_t *)reg)->metrics[CWIST_METRIC_HTTP_CONTINUATION_SHED].value.raw,
+                          (uintmax_t)shed * 1000, memory_order_relaxed);
+    atomic_store_explicit(&((cwist_metrics_registry_t *)reg)->metrics[CWIST_METRIC_HTTP_CONTINUATION_SHED].count,
+                          (uintmax_t)shed, memory_order_relaxed);
 
     size_t cap = 4096;
     char *buf = malloc(cap);

--- a/tests/test_cookie.c
+++ b/tests/test_cookie.c
@@ -1,0 +1,136 @@
+/**
+ * @file test_cookie.c
+ * @brief Unit tests for HTTP cookie parsing, encoding, decoding, and header generation.
+ */
+
+#include <cwist/net/http/cookie.h>
+#include <cwist/net/http/http.h>
+#include <cwist/net/http/query.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+
+static void test_cookie_encode(void) {
+    printf("Testing cookie encode...\n");
+    char *encoded = cwist_cookie_encode("hello world; test=1");
+    assert(encoded != NULL);
+    assert(strstr(encoded, "%20") != NULL);
+    assert(strstr(encoded, "%3B") != NULL);
+    assert(strstr(encoded, "%3D") != NULL);
+    free(encoded);
+
+    /* Clean alphanumeric should not change */
+    char *clean = cwist_cookie_encode("abc-123_xyz.~");
+    assert(clean != NULL);
+    assert(strcmp(clean, "abc-123_xyz.~") == 0);
+    free(clean);
+    printf("  Passed encode.\n");
+}
+
+static void test_cookie_decode(void) {
+    printf("Testing cookie decode...\n");
+    char out[128];
+
+    /* Basic hex decoding and + as space */
+    int len = cwist_cookie_decode("hello+world%21%2A", out, sizeof(out));
+    assert(len == 13);
+    assert(strcmp(out, "hello world!*") == 0);
+
+    /* Lowercase hex */
+    len = cwist_cookie_decode("%2fpath%2fa", out, sizeof(out));
+    assert(len == 7);
+    assert(strcmp(out, "/path/a") == 0);
+
+    /* Incomplete/malformed percent sequences treated safely as literal */
+    len = cwist_cookie_decode("abc%1gdef%", out, sizeof(out));
+    assert(len > 0);
+    assert(strcmp(out, "abc%1gdef%") == 0);
+
+    /* Small buffer overflow protection */
+    char small[4];
+    int rc = cwist_cookie_decode("toolongstring", small, sizeof(small));
+    assert(rc == -1);
+
+    printf("  Passed decode.\n");
+}
+
+static void test_cookie_parse_and_get(void) {
+    printf("Testing cookie parse and get...\n");
+    cwist_query_map *map = cwist_query_map_create();
+    assert(map != NULL);
+
+    const char *header = "session_id=s%20123; user=alice; theme=dark; ; =empty;   spaced   =value  ";
+    cwist_cookie_parse(map, header);
+
+    const char *session = cwist_cookie_get(map, "session_id");
+    assert(session != NULL && strcmp(session, "s 123") == 0);
+
+    const char *user = cwist_cookie_get(map, "user");
+    assert(user != NULL && strcmp(user, "alice") == 0);
+
+    const char *theme = cwist_cookie_get(map, "theme");
+    assert(theme != NULL && strcmp(theme, "dark") == 0);
+
+    const char *spaced = cwist_cookie_get(map, "spaced");
+    assert(spaced != NULL && strcmp(spaced, "value  ") == 0);
+
+    /* Empty name or missing cookies should return NULL */
+    assert(cwist_cookie_get(map, "") == NULL);
+    assert(cwist_cookie_get(map, "missing") == NULL);
+
+    cwist_query_map_destroy(map);
+    printf("  Passed parse and get.\n");
+}
+
+static void test_cookie_set_and_delete(void) {
+    printf("Testing cookie set and delete...\n");
+    cwist_http_response *res = cwist_http_response_create();
+    assert(res != NULL);
+
+    cwist_cookie_options opts = {
+        .path = "/api",
+        .domain = "example.com",
+        .max_age_seconds = 3600,
+        .http_only = true,
+        .secure = true,
+        .same_site = "Lax",
+    };
+
+    int rc = cwist_cookie_set(res, "auth_token", "xyz 789", &opts);
+    assert(rc == 0);
+
+    const char *set_cookie = cwist_http_header_get(res->headers, "Set-Cookie");
+    assert(set_cookie != NULL);
+    assert(strstr(set_cookie, "auth_token=xyz%20789") != NULL);
+    assert(strstr(set_cookie, "Path=/api") != NULL);
+    assert(strstr(set_cookie, "Domain=example.com") != NULL);
+    assert(strstr(set_cookie, "Max-Age=3600") != NULL);
+    assert(strstr(set_cookie, "HttpOnly") != NULL);
+    assert(strstr(set_cookie, "Secure") != NULL);
+    assert(strstr(set_cookie, "SameSite=Lax") != NULL);
+
+    /* Delete cookie */
+    cwist_http_response *del_res = cwist_http_response_create();
+    assert(del_res != NULL);
+    rc = cwist_cookie_delete(del_res, "auth_token");
+    assert(rc == 0);
+
+    const char *del_cookie = cwist_http_header_get(del_res->headers, "Set-Cookie");
+    assert(del_cookie != NULL);
+    assert(strstr(del_cookie, "auth_token=;") != NULL);
+    assert(strstr(del_cookie, "Max-Age=0") != NULL);
+
+    cwist_http_response_destroy(res);
+    cwist_http_response_destroy(del_res);
+    printf("  Passed set and delete.\n");
+}
+
+int main(void) {
+    test_cookie_encode();
+    test_cookie_decode();
+    test_cookie_parse_and_get();
+    test_cookie_set_and_delete();
+    printf("All cookie tests passed!\n");
+    return 0;
+}

--- a/tests/test_json_heal.c
+++ b/tests/test_json_heal.c
@@ -65,6 +65,30 @@ static void test_l1_trailing_comma(void) {
     printf("  Passed.\n");
 }
 
+static void test_l1_string_with_comma_and_closer(void) {
+    printf("L1: comma followed by closer inside string literal preserved...\n");
+    const char *input = "{\"query\":\"SELECT a, } FROM t\",\"items\":[\"x, ]\", 1,]}";
+    cwist_heal_result_t r = cwist_json_heal(input, NULL);
+    assert(r.json   != NULL);
+    assert(r.healed == true);
+    assert(r.level  == 1);
+
+    cJSON *parsed = cJSON_Parse(r.json);
+    assert(parsed != NULL);
+    cJSON *q = cJSON_GetObjectItem(parsed, "query");
+    assert(q && strcmp(q->valuestring, "SELECT a, } FROM t") == 0);
+    cJSON *items = cJSON_GetObjectItem(parsed, "items");
+    assert(items && cJSON_GetArraySize(items) == 2);
+    cJSON *item0 = cJSON_GetArrayItem(items, 0);
+    assert(item0 && strcmp(item0->valuestring, "x, ]") == 0);
+    cJSON *item1 = cJSON_GetArrayItem(items, 1);
+    assert(item1 && item1->valueint == 1);
+    cJSON_Delete(parsed);
+
+    cwist_heal_result_free(&r);
+    printf("  Passed.\n");
+}
+
 static void test_l1_missing_closers(void) {
     printf("L1: missing closing brace and bracket...\n");
     const char *input = "{\"items\":[1,2,3";
@@ -438,6 +462,7 @@ int main(void) {
     printf("=== L1 Syntax Healing ===\n");
     test_l1_already_valid();
     test_l1_trailing_comma();
+    test_l1_string_with_comma_and_closer();
     test_l1_missing_closers();
     test_l1_line_comment();
     test_l1_bom();

--- a/tests/test_metrics.c
+++ b/tests/test_metrics.c
@@ -149,9 +149,30 @@ void test_metrics_middleware_wiring(void) {
     printf("  OK\n");
 }
 
+void test_metrics_continuation_shed(void) {
+    printf("test_metrics_continuation_shed...\n");
+    cwist_metrics_registry_t *reg = cwist_metrics_registry();
+    assert(reg != NULL);
+
+    long initial_shed = cwist_http_continuation_shed_count();
+    assert(initial_shed >= 0);
+
+    uintmax_t metric_val = cwist_metric_load(reg, CWIST_METRIC_HTTP_CONTINUATION_SHED);
+    assert(metric_val == (uintmax_t)initial_shed);
+
+    char *text = cwist_metrics_render_prometheus(reg);
+    assert(text != NULL);
+    assert(strstr(text, "cwist_http_continuation_shed_total") != NULL);
+    assert(strstr(text, "# HELP cwist_http_continuation_shed_total") != NULL);
+    assert(strstr(text, "# TYPE cwist_http_continuation_shed_total counter") != NULL);
+    free(text);
+    printf("  OK\n");
+}
+
 int main(void) {
     test_metrics_counter();
     test_metrics_gauge();
+    test_metrics_continuation_shed();
     test_metrics_prometheus_render();
     test_metrics_http_response();
     test_healthz_ok();

--- a/tests/test_seq.c
+++ b/tests/test_seq.c
@@ -170,6 +170,37 @@ static void test_conflicting_duplicate_rejected(void) {
     printf("  Passed conflicting duplicate rejection.\n");
 }
 
+static void test_reset_preserves_limit(void) {
+    printf("Testing reset preserves max_data_len limit...\n");
+    /* Create assembler with 10-byte ceiling */
+    cwist_seq_assembler_t *a = cwist_seq_assembler_create_limited(10);
+    assert(a != NULL);
+
+    /* Valid 4-byte message fits within 10-byte limit */
+    const char *msg1 = "test";
+    cwist_seq_message_t split1;
+    assert(cwist_seq_split((const uint8_t *)msg1, strlen(msg1), 4, &split1));
+    cwist_seq_chunk_t chunk;
+    assert(cwist_seq_chunk_parse(split1.chunks[0], split1.chunk_lens[0], &chunk));
+    assert(cwist_seq_assembler_feed(a, &chunk));
+    assert(cwist_seq_assembler_is_complete(a));
+    cwist_seq_message_free(&split1);
+
+    /* Reset the assembler */
+    cwist_seq_assembler_reset(a);
+
+    /* Oversized message (20 bytes > 10-byte ceiling) must still be rejected after reset */
+    const char *msg2 = "01234567890123456789";
+    cwist_seq_message_t split2;
+    assert(cwist_seq_split((const uint8_t *)msg2, strlen(msg2), 10, &split2));
+    assert(cwist_seq_chunk_parse(split2.chunks[0], split2.chunk_lens[0], &chunk));
+    assert(!cwist_seq_assembler_feed(a, &chunk)); /* rejected because 20 > 10 */
+
+    cwist_seq_assembler_destroy(a);
+    cwist_seq_message_free(&split2);
+    printf("  Passed reset preserves limit.\n");
+}
+
 int main(void) {
     test_split_and_reassemble();
     test_duplicate_discard();
@@ -177,6 +208,7 @@ int main(void) {
     test_single_chunk();
     test_final_chunk_first_recovery_targets();
     test_conflicting_duplicate_rejected();
+    test_reset_preserves_limit();
     printf("All seq tests passed!\n");
     return 0;
 }


### PR DESCRIPTION
## Root cause

PR #46 (`sync/dev-to-main-20260913`) cherry-picked "the last 7 actual
change commits from dev" by count, not by diff against main. By the time
it was merged, 4 more real commits had landed on `dev` from
@thegoodengineer (PRs #40, #42, #43, #44) - all of them merged *before*
#46's merge timestamp, but outside the fixed 7-commit window someone
counted earlier. Only one of the five `thegoodengineer` commits (#41,
sstring) made it into main; #40/#42/#43/#44 were silently dropped.

## What this does

Cherry-picks the 4 missing commits from `dev` onto `main`, in the order
they were merged into `dev`, each with authorship preserved
(`git cherry-pick` keeps the original Author; only Committer/date changes):

* `06bb843f` → `fix(cookie): validate hex digits in cookie decode, fix pointer underflow in parser, and add tests` (#44)
* `7953529d` → `feat(metrics): expose HTTP continuation shed counter in /metrics and document CWIST_HTTP_BATCH` (#40)
* `22289f05` → `fix(json_heal): preserve commas inside string literals during trailing comma healing` (#42)
* `2bed589d` → `fix(seq): preserve max_data_len limit across assembler resets` (#43)

All four are Abhijeet Sharma (`meetabhijeet05@gmail.com`), matching their
original PRs.

## Verification

- `make libcwist.a` builds clean against `main` + these 4 commits.
- Ran the affected test binaries directly (not just compiled):
  `test_cookie`, `test_metrics`, `test_json_heal`, `test_seq` - all pass.

## Going forward

Doing this by commit count is what caused the gap; a future dev→main sync
should diff against main's current tip (e.g. commits reachable from `dev`
but not `main`) rather than picking a fixed N.
