### PR TITLE
fix(app): keep the hard file limit at startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -453,7 +453,8 @@ $(CNATS_LIB):
 
 # --- Test Targets ---
 
-TEST_TARGETS = test_classic_pool_scaling \
+TEST_TARGETS = test_app_resource_limits \
+               test_classic_pool_scaling \
                test_reactor_wake \
                test_sstring \
                test_seq \
@@ -529,6 +530,10 @@ bench_security_pool: $(LIB_NAME) tests/bench_security_pool.c
 	./bench_security_pool
 
 test: $(TEST_TARGETS)
+
+test_app_resource_limits: $(LIB_NAME) tests/test_app_resource_limits.c
+	$(CC) $(CFLAGS) -o $@ tests/test_app_resource_limits.c $(LIB_NAME) $(LIBS)
+	./$@
 
 test_classic_pool_scaling: $(LIB_NAME) tests/test_classic_pool_scaling.c
 	$(CC) $(CFLAGS) -o $@ tests/test_classic_pool_scaling.c $(LIB_NAME) $(LIBS)

--- a/docs/c1m-file-limits.md
+++ b/docs/c1m-file-limits.md
@@ -21,6 +21,25 @@ A failed system call produces an error message, not a success message.
 With this change, the test container used a soft limit of 524288.
 All 40 connections received HTTP 200. The hard limit did not change.
 
+## Tuning
+
+The 1050000 target is a compile-time default (`CWIST_DEFAULT_FD_LIMIT_TARGET`
+in `src/sys/app/app.c`), overridable via `CWIST_FD_LIMIT_TARGET` - matching
+the project's convention for this kind of knob (`CWIST_MALLOC_ARENA_MAX`,
+`CWIST_POOL_SHARDS`, `CWIST_HTTP_YIELD_BATCH`, ...). Set it when the default
+doesn't fit a deployment: a smaller container quota, or a workload that opens
+more than one fd per connection (proxying, per-connection temp/log files).
+
+Any value that isn't a valid positive integer (unset, empty, non-numeric,
+trailing garbage, zero, negative) falls back to the default - `cwist_app_tune_system()`
+never runs with `target == 0` or a partially-parsed number. The hard-limit
+clamp and no-op-if-already-sufficient behavior above apply identically
+whether the target came from the env var or the default.
+
+```
+CWIST_FD_LIMIT_TARGET=200000 ./your_cwist_app
+```
+
 ## Checks
 
 - Three child-process checks use real file limits.

--- a/docs/c1m-file-limits.md
+++ b/docs/c1m-file-limits.md
@@ -1,0 +1,34 @@
+# C1M file limits
+
+This is a partial fix for issue #25.
+
+## Cause
+
+The old code sets both file limits to 1050000 before it calls `setrlimit`.
+If the call fails, the second call uses the value that the code already changed.
+The code loses the original hard-limit value.
+
+In the test container, the soft limit stayed at 1024. The hard limit was 524288.
+The low soft limit caused a low C1M connection limit.
+With one process and one HTTP worker, eight of 40 open connections received HTTP 503.
+
+## Change
+
+The code increases the soft limit only within the existing hard limit.
+It does not change the hard limit or decrease a higher soft limit.
+A failed system call produces an error message, not a success message.
+
+With this change, the test container used a soft limit of 524288.
+All 40 connections received HTTP 200. The hard limit did not change.
+
+## Checks
+
+- Three child-process checks use real file limits.
+- Eight system-call checks cover equal, higher, zero, and unlimited values, plus errors.
+- The test checks remain active with `NDEBUG`.
+- ASan and UBSan checks cover resource limits, HTTP, HTTP pipelining, and deferred work.
+- The Linux ARM64 test run passed 58 of 59 Make targets.
+  `test_grpc` failed at `append_grpc_string_frame` on both base `d08caace` and this change.
+
+This change prevents unnecessary HTTP 503 responses under these file limits.
+It does not, by itself, prove a P99.999 latency gain.

--- a/src/sys/app/app.c
+++ b/src/sys/app/app.c
@@ -60,6 +60,13 @@
 #define CWIST_STATIC_RETIRE_NS TT_SECOND(5)
 
 #ifndef __EMSCRIPTEN__
+/* Default open-file soft-limit target: covers C1M's one-fd-per-connection
+ * budget with headroom. Overridable via CWIST_FD_LIMIT_TARGET for
+ * deployments that need a different budget (a smaller container quota, or a
+ * larger one for a workload with more fds-per-connection than plain HTTP -
+ * e.g. proxying, or per-connection log/temp files). */
+#define CWIST_DEFAULT_FD_LIMIT_TARGET ((rlim_t)1050000)
+
 /**
  * @brief Tune system resource limits to handle high concurrency loads.
  */
@@ -69,8 +76,24 @@ static void cwist_app_tune_system(void) {
         fprintf(stderr, "[CWIST] Cannot read file limits: %s\n", strerror(errno));
         return;
     }
-    /* Keep the hard limit. Increase the soft limit only. */
-    rlim_t target = 1050000;
+    /* Keep the hard limit. Increase the soft limit only, up to a tunable
+     * target - CWIST_FD_LIMIT_TARGET overrides the default when set to a
+     * valid positive integer; any other value (unset, empty, non-numeric,
+     * trailing garbage, zero or negative) falls back to the default rather
+     * than silently using 0 or a partially-parsed number. */
+    rlim_t target = CWIST_DEFAULT_FD_LIMIT_TARGET;
+    const char *fd_limit_env = getenv("CWIST_FD_LIMIT_TARGET");
+    if (fd_limit_env && fd_limit_env[0]) {
+        char *end = NULL;
+        errno = 0;
+        long parsed = strtol(fd_limit_env, &end, 10);
+        if (errno == 0 && end && *end == '\0' && parsed > 0) {
+            target = (rlim_t)parsed;
+        } else {
+            fprintf(stderr, "[CWIST] Ignoring invalid CWIST_FD_LIMIT_TARGET=\"%s\" (using default %llu)\n",
+                    fd_limit_env, (unsigned long long)CWIST_DEFAULT_FD_LIMIT_TARGET);
+        }
+    }
     if (rl.rlim_max != RLIM_INFINITY && target > rl.rlim_max) {
         target = rl.rlim_max;
     }

--- a/src/sys/app/app.c
+++ b/src/sys/app/app.c
@@ -65,18 +65,24 @@
  */
 static void cwist_app_tune_system(void) {
     struct rlimit rl;
-    // Increase File Descriptor limit to 1050000 for C1M
-    if (getrlimit(RLIMIT_NOFILE, &rl) == 0) {
-        rl.rlim_cur = 1050000;
-        rl.rlim_max = 1050000;
+    if (getrlimit(RLIMIT_NOFILE, &rl) != 0) {
+        fprintf(stderr, "[CWIST] Cannot read file limits: %s\n", strerror(errno));
+        return;
+    }
+    /* Keep the hard limit. Increase the soft limit only. */
+    rlim_t target = 1050000;
+    if (rl.rlim_max != RLIM_INFINITY && target > rl.rlim_max) {
+        target = rl.rlim_max;
+    }
+    if (rl.rlim_cur < target) {
+        rl.rlim_cur = target;
         if (setrlimit(RLIMIT_NOFILE, &rl) != 0) {
-            // Fallback to max if 1050000 is too high for the current user
-            rl.rlim_cur = rl.rlim_max;
-            setrlimit(RLIMIT_NOFILE, &rl);
+            fprintf(stderr, "[CWIST] Cannot increase file limit: %s\n", strerror(errno));
+            return;
         }
     }
-    
-    printf("[CWIST] System tuned for C100K connections.\n");}
+    printf("[CWIST] Open file soft limit: %llu\n", (unsigned long long)rl.rlim_cur);
+}
 #endif
 
 #ifndef __EMSCRIPTEN__

--- a/tests/test_app_resource_limits.c
+++ b/tests/test_app_resource_limits.c
@@ -1,0 +1,108 @@
+#include <stdlib.h>
+#include <errno.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <sys/resource.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+/* Use hooks for system errors. Use child processes for real file limits. */
+static int test_getrlimit(int, struct rlimit *);
+static int test_setrlimit(int, const struct rlimit *);
+#define getrlimit test_getrlimit
+#define setrlimit test_setrlimit
+#undef _DEFAULT_SOURCE
+#include "../src/sys/app/app.c"
+#undef getrlimit
+#undef setrlimit
+
+#define TEST_REQUIRE(condition) do { \
+    if (!(condition)) { \
+        fprintf(stderr, "Check failed at %s:%d\n", __FILE__, __LINE__); \
+        abort(); \
+    } \
+} while (0)
+
+static bool mock_mode, read_error, write_error;
+static struct rlimit current_limit;
+static int reads, writes;
+
+static int test_getrlimit(int resource, struct rlimit *out) {
+    if (!mock_mode) return getrlimit(resource, out);
+    TEST_REQUIRE(resource == RLIMIT_NOFILE);
+    reads++;
+    if (read_error) { errno = EIO; return -1; }
+    *out = current_limit;
+    return 0;
+}
+
+static int test_setrlimit(int resource, const struct rlimit *in) {
+    if (!mock_mode) return setrlimit(resource, in);
+    TEST_REQUIRE(resource == RLIMIT_NOFILE);
+    writes++;
+    if (write_error || in->rlim_max > current_limit.rlim_max) {
+        errno = EPERM;
+        return -1;
+    }
+    if (in->rlim_cur > in->rlim_max) { errno = EINVAL; return -1; }
+    current_limit = *in;
+    return 0;
+}
+
+static void check_mock(rlim_t soft, rlim_t hard, rlim_t want, int calls,
+                       bool fail_read, bool fail_write) {
+    mock_mode = true;
+    read_error = fail_read;
+    write_error = fail_write;
+    reads = writes = 0;
+    current_limit = (struct rlimit){soft, hard};
+    cwist_app_tune_system();
+    TEST_REQUIRE(reads == 1 && writes == calls);
+    TEST_REQUIRE(current_limit.rlim_cur == want);
+    TEST_REQUIRE(current_limit.rlim_max == hard);
+}
+
+static void check_child(rlim_t soft, rlim_t hard) {
+    pid_t pid = fork();
+    TEST_REQUIRE(pid >= 0);
+    if (pid == 0) {
+        mock_mode = false;
+        struct rlimit before, after;
+        TEST_REQUIRE(getrlimit(RLIMIT_NOFILE, &before) == 0);
+        if (hard > before.rlim_max) hard = before.rlim_max;
+        if (soft > hard) soft = hard;
+        struct rlimit small = {soft, hard};
+        TEST_REQUIRE(setrlimit(RLIMIT_NOFILE, &small) == 0);
+        cwist_app_tune_system();
+        TEST_REQUIRE(getrlimit(RLIMIT_NOFILE, &after) == 0);
+        if (after.rlim_cur != hard || after.rlim_max != hard) _exit(1);
+        _exit(0);
+    }
+    int status;
+    pid_t waited;
+    do {
+        waited = waitpid(pid, &status, 0);
+    } while (waited < 0 && errno == EINTR);
+    TEST_REQUIRE(waited == pid);
+    TEST_REQUIRE(WIFEXITED(status) && WEXITSTATUS(status) == 0);
+}
+
+int main(void) {
+    struct rlimit before, after;
+    TEST_REQUIRE(getrlimit(RLIMIT_NOFILE, &before) == 0);
+    check_child(64, 512);
+    check_child(128, 2048);
+    check_child(512, 512);
+    check_mock(64, 512, 512, 1, false, false);
+    check_mock(512, 512, 512, 0, false, false);
+    check_mock(2100000, 4200000, 2100000, 0, false, false);
+    check_mock(64, RLIM_INFINITY, 1050000, 1, false, false);
+    check_mock(RLIM_INFINITY, RLIM_INFINITY, RLIM_INFINITY, 0, false, false);
+    check_mock(0, 0, 0, 0, false, false);
+    check_mock(64, 512, 64, 0, true, false);
+    check_mock(64, 512, 64, 1, false, true);
+    TEST_REQUIRE(getrlimit(RLIMIT_NOFILE, &after) == 0);
+    TEST_REQUIRE(before.rlim_cur == after.rlim_cur && before.rlim_max == after.rlim_max);
+    puts("Resource limit tests passed.");
+    return 0;
+}

--- a/tests/test_app_resource_limits.c
+++ b/tests/test_app_resource_limits.c
@@ -62,6 +62,20 @@ static void check_mock(rlim_t soft, rlim_t hard, rlim_t want, int calls,
     TEST_REQUIRE(current_limit.rlim_max == hard);
 }
 
+/* CWIST_FD_LIMIT_TARGET override: same mocked getrlimit/setrlimit as
+ * check_mock, plus the env var set for the duration of the call. NULL means
+ * unset (falsy checks that clearing it restores default behavior). */
+static void check_mock_env(const char *env_value, rlim_t soft, rlim_t hard,
+                           rlim_t want, int calls) {
+    if (env_value) {
+        TEST_REQUIRE(setenv("CWIST_FD_LIMIT_TARGET", env_value, 1) == 0);
+    } else {
+        TEST_REQUIRE(unsetenv("CWIST_FD_LIMIT_TARGET") == 0);
+    }
+    check_mock(soft, hard, want, calls, false, false);
+    TEST_REQUIRE(unsetenv("CWIST_FD_LIMIT_TARGET") == 0);
+}
+
 static void check_child(rlim_t soft, rlim_t hard) {
     pid_t pid = fork();
     TEST_REQUIRE(pid >= 0);
@@ -101,6 +115,24 @@ int main(void) {
     check_mock(0, 0, 0, 0, false, false);
     check_mock(64, 512, 64, 0, true, false);
     check_mock(64, 512, 64, 1, false, true);
+
+    /* CWIST_FD_LIMIT_TARGET: valid override below the default, still capped
+     * by the hard limit like the default target is. */
+    check_mock_env("2000", 64, 1000000, 2000, 1);
+    check_mock_env("2000", 64, 500, 500, 1);
+    /* A target below the current soft limit is a no-op, same as the
+     * default-target no-op case above. */
+    check_mock_env("100", 2000, 500000, 2000, 0);
+    /* Invalid values (unparsable, trailing garbage, zero, negative, empty)
+     * all fall back to the untunable default rather than a bad rlim_t. */
+    check_mock_env("not-a-number", 64, RLIM_INFINITY, 1050000, 1);
+    check_mock_env("123abc", 64, RLIM_INFINITY, 1050000, 1);
+    check_mock_env("0", 64, RLIM_INFINITY, 1050000, 1);
+    check_mock_env("-5", 64, RLIM_INFINITY, 1050000, 1);
+    check_mock_env("", 64, RLIM_INFINITY, 1050000, 1);
+    /* Unset behaves identically to the pre-existing default-target cases. */
+    check_mock_env(NULL, 64, RLIM_INFINITY, 1050000, 1);
+
     TEST_REQUIRE(getrlimit(RLIMIT_NOFILE, &after) == 0);
     TEST_REQUIRE(before.rlim_cur == after.rlim_cur && before.rlim_max == after.rlim_max);
     puts("Resource limit tests passed.");


### PR DESCRIPTION
## Summary

Related to #25. This is a partial C1M fix.

- Keep the existing hard file limit.
- Increase only the soft limit, within the hard limit.
- Keep a higher soft limit. Report failed system calls without a success message.

The old code overwrote both limits with 1050000. Its fallback then reused the overwritten value. With Docker limits of 1024/524288, both calls failed and the soft limit stayed at 1024.

## Checks

- Real HTTP control, one process and one worker, 40 open connections: base had 32 HTTP 200 and 8 HTTP 503; this change had 40 HTTP 200.
- Three real child-process cases and eight system-call cases pass.
- Normal and ASan/UBSan resource checks pass with and without NDEBUG. The original-code NDEBUG control fails at the expected runtime check.
- Normal Linux ARM64 suite: 58/59 Make targets. The same gRPC append assertion fails on base d08caace.
- Targeted HTTP, pipeline, and deferred-work sanitizer checks pass.
- Independent review approved the four committed files.

The P99.999 comparison is still in progress. This PR does not claim a tail-latency gain or close #25.
