### PR TITLE
fix(jwt): reject base64url remainder of 1 and validate chunk feed

### DIFF
--- a/src/security/jwt/jwt.c
+++ b/src/security/jwt/jwt.c
@@ -118,6 +118,11 @@ static unsigned char *b64url_decode(const char *src, size_t src_len, size_t *out
         if (a < 0 || b < 0 || c < 0) { cwist_free(out); return NULL; }
         out[j++] = (unsigned char)((a << 2) | (b >> 4));
         out[j++] = (unsigned char)((b << 4) | (c >> 2));
+    } else if (rem == 1) {
+        /* RFC 4648 §4: 1 base64 character (6 bits) cannot encode a whole byte.
+         * A remainder of 1 is malformed and must be rejected. */
+        cwist_free(out);
+        return NULL;
     }
 
     out[j] = '\0';
@@ -424,7 +429,10 @@ char *cwist_jwt_join_chunks(const cwist_jwt_chunk_t *chunks, size_t count) {
             cwist_seq_assembler_destroy(a);
             return NULL;
         }
-        cwist_seq_assembler_feed(a, &chunk);
+        if (!cwist_seq_assembler_feed(a, &chunk)) {
+            cwist_seq_assembler_destroy(a);
+            return NULL;
+        }
     }
 
     const uint8_t *data = NULL;

--- a/tests/test_jwt.c
+++ b/tests/test_jwt.c
@@ -189,6 +189,53 @@ static void test_sign_verify_chunks(void) {
     printf("  Passed sign/verify chunks.\n");
 }
 
+static void test_malformed_b64url_remainder(void) {
+    printf("Testing JWT reject malformed base64 remainder (rem == 1)...\n");
+
+    const char *secret = "secret";
+    char *token = cwist_jwt_sign("{\"sub\":\"test\"}", secret, 3600);
+    assert(token != NULL);
+
+    /* Construct an invalid token by appending a single character to the payload (length % 4 == 1) */
+    char malformed[512];
+    char *dot1 = strchr(token, '.');
+    char *dot2 = dot1 ? strchr(dot1 + 1, '.') : NULL;
+    assert(dot1 && dot2);
+
+    size_t header_len = (size_t)(dot1 - token);
+    size_t payload_len = (size_t)(dot2 - dot1 - 1);
+    /* Make payload section length % 4 == 1 */
+    size_t new_payload_len = ((payload_len / 4) * 4) + 1;
+    snprintf(malformed, sizeof(malformed), "%.*s.%.*s.%s",
+             (int)header_len, token,
+             (int)new_payload_len, dot1 + 1,
+             dot2 + 1);
+
+    cwist_jwt_claims *claims = cwist_jwt_verify(malformed, secret);
+    assert(claims == NULL); /* Must be rejected */
+
+    cwist_free(token);
+    printf("  Passed malformed base64 remainder rejection.\n");
+}
+
+static void test_corrupt_chunk_feed(void) {
+    printf("Testing JWT join chunks failure handling on feed error...\n");
+
+    /* Single chunk with corrupted seq total (e.g. index > total) */
+    cwist_jwt_chunk_t corrupt_chunk;
+    corrupt_chunk.data = (uint8_t *)cwist_alloc(16);
+    assert(corrupt_chunk.data != NULL);
+    /* Manually craft chunk with chunk index 5 of 2 (invalid) */
+    snprintf((char *)corrupt_chunk.data, 16, "[5/2]test");
+    corrupt_chunk.len = strlen((char *)corrupt_chunk.data);
+
+    char *joined = cwist_jwt_join_chunks(&corrupt_chunk, 1);
+    assert(joined == NULL);
+
+    cwist_free(corrupt_chunk.data);
+    printf("  Passed corrupt chunk feed rejection.\n");
+}
+
 int main(void) {
     test_sign_and_verify();
     test_wrong_secret();
@@ -197,6 +244,8 @@ int main(void) {
     test_no_exp();
     test_sequenced_chunks();
     test_sign_verify_chunks();
+    test_malformed_b64url_remainder();
+    test_corrupt_chunk_feed();
     printf("All JWT tests passed!\n");
     return 0;
 }


### PR DESCRIPTION
### Summary of Changes

1. **Base64URL remainder validation (`RFC 4648 §4`)**:
   - In `b64url_decode()`, a Base64 remainder of 1 6-bit character (`padded_len - i == 1`) is mathematically impossible for valid Base64 data (a single 6-bit unit cannot encode an 8-bit byte).
   - Previously, if `rem == 1`, the function fell through the `if (rem == 2)` / `else if (rem == 3)` blocks and returned the partially decoded buffer as valid.
   - Now explicitly checks `else if (rem == 1)` and frees the buffer and returns `NULL`.

2. **Chunk feed error handling in `cwist_jwt_join_chunks()`**:
   - `cwist_seq_assembler_feed()` returns `false` if chunk sequence validation fails or the chunk cannot be accepted.
   - Previously, the return value was ignored and parsing continued.
   - Now checks the return value; if feeding fails, cleans up the assembler and returns `NULL`.

3. **Unit Tests**:
   - Added `test_malformed_b64url_remainder()` to `tests/test_jwt.c` to verify that tokens with remainder 1 are rejected.
   - Added `test_corrupt_chunk_feed()` to `tests/test_jwt.c` to verify that chunk join properly fails when feeding corrupted chunks.
