### PR TITLE
fix(sstring): correct html escape entity typo for > and avoid redundant allocations

### DIFF
--- a/src/core/sstring/sstring.c
+++ b/src/core/sstring/sstring.c
@@ -521,19 +521,24 @@ cwist_error_t cwist_sstring_append_escaped(cwist_sstring *str, const char *data)
     size_t input_len = strlen(data);
     size_t new_size = current_len + (input_len * 6) + 1;
 
-    cwist_error_t err = make_error(CWIST_ERR_JSON);
-    err.error.err_json = cJSON_CreateObject();
-
     if (str->is_fixed) {
         if (new_size > str->size) {
-            cJSON_AddStringToObject(err.error.err_json, "err", "Cannot append: would exceed fixed size");
+            cwist_error_t err = make_error(CWIST_ERR_JSON);
+            err.error.err_json = cJSON_CreateObject();
+            if (err.error.err_json) {
+                cJSON_AddStringToObject(err.error.err_json, "err", "Cannot append: would exceed fixed size");
+            }
             return err;
         }
     } else {
         char *new_data = cwist_sstring_reserve(str, new_size, current_len);
         if (!new_data) {
-             cJSON_AddStringToObject(err.error.err_json, "err", "Cannot append: memory full");
-             return err;
+            cwist_error_t err = make_error(CWIST_ERR_JSON);
+            err.error.err_json = cJSON_CreateObject();
+            if (err.error.err_json) {
+                cJSON_AddStringToObject(err.error.err_json, "err", "Cannot append: memory full");
+            }
+            return err;
         }
         str->data = new_data;
         str->borrows_buffer = false;
@@ -548,7 +553,7 @@ cwist_error_t cwist_sstring_append_escaped(cwist_sstring *str, const char *data)
                 ptr += 4;
                 break;
             case '>':
-                memcpy(ptr, "&gtl", 4);
+                memcpy(ptr, "&gt;", 4);
                 ptr += 4;
                 break;
             case '&':
@@ -572,8 +577,7 @@ cwist_error_t cwist_sstring_append_escaped(cwist_sstring *str, const char *data)
     *ptr = '\0';
     str->size = (size_t) (ptr - str->data);
 
-    cJSON_Delete(err.error.err_json);
-    err = make_error(CWIST_ERR_INT8);
+    cwist_error_t err = make_error(CWIST_ERR_INT8);
     err.error.err_i8 = ERR_SSTRING_OKAY;
     return err;
 }

--- a/tests/test_sstring.c
+++ b/tests/test_sstring.c
@@ -159,6 +159,34 @@ void test_sstring_ops() {
     printf("Passed sstring-to-sstring ops.\n");
 }
 
+void test_html_escape() {
+    printf("Testing html escape...\n");
+    cwist_sstring *s = cwist_sstring_create();
+    assert(s != NULL);
+
+    cwist_error_t err = cwist_sstring_append_escaped(s, "<div class=\"alert\">Bob & Alice's test > 0</div>");
+    assert(err.errtype == CWIST_ERR_INT8 && err.error.err_i8 == ERR_SSTRING_OKAY);
+    assert(strcmp(s->data, "&lt;div class=&quot;alert&quot;&gt;Bob &amp; Alice&#39;s test &gt; 0&lt;/div&gt;") == 0);
+    assert(cwist_sstring_get_size(s) == strlen("&lt;div class=&quot;alert&quot;&gt;Bob &amp; Alice&#39;s test &gt; 0&lt;/div&gt;"));
+
+    /* Test NULL string and NULL data safety */
+    err = cwist_sstring_append_escaped(NULL, "test");
+    assert(err.errtype == CWIST_ERR_INT8 && err.error.err_i8 == ERR_SSTRING_NULL_STRING);
+
+    err = cwist_sstring_append_escaped(s, NULL);
+    assert(err.errtype == CWIST_ERR_INT8 && err.error.err_i8 == ERR_SSTRING_OKAY);
+
+    /* Test standalone > character */
+    cwist_sstring *s2 = cwist_sstring_create();
+    cwist_sstring_append_escaped(s2, ">");
+    assert(strcmp(s2->data, "&gt;") == 0);
+    assert(cwist_sstring_get_size(s2) == 4);
+
+    cwist_sstring_destroy(s);
+    cwist_sstring_destroy(s2);
+    printf("Passed html escape.\n");
+}
+
 int main() {
     test_trim();
     test_resize();
@@ -166,6 +194,8 @@ int main() {
     test_compare();
     test_substr();
     test_sstring_ops();
+    test_html_escape();
     printf("All tests passed!\n");
     return 0;
 }
+


### PR DESCRIPTION
## Summary
This PR fixes an HTML escaping corruption bug and avoids redundant heap allocations in `cwist_sstring_append_escaped`:

1. **Fix entity typo for `>` character**:
   - In `src/core/sstring/sstring.c`, escaping `>` wrote `&gtl` instead of the valid HTML entity `&gt;`:
     ```c
     case '>':
         memcpy(ptr, "&gtl", 4); // replaced with "&gt;"
     ```
   - This caused corrupt HTML output whenever greater-than characters were escaped.

2. **Eliminate unnecessary heap allocation on success**:
   - `cwist_sstring_append_escaped()` was unconditionally allocating `err.error.err_json = cJSON_CreateObject()` at the start of the function and freeing it at the end on success.
   - Now, `cJSON_CreateObject()` is only allocated when an actual error occurs (e.g. fixed buffer overflow or out of memory).

3. **Tests**:
   - Added `test_html_escape()` in `tests/test_sstring.c` verifying escaping of `<`, `>`, `&`, `"`, `'`, standalone `>`, and handling of NULL pointers.

## Testing
- Successfully compiled and ran `tests/test_sstring.c` on Linux/WSL. All tests passed. Target branch: `dev`.
