### PR TITLE
fix(html): escape attribute values and support boolean and numeric attributes safely

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -511,7 +511,8 @@ TEST_TARGETS = test_classic_pool_scaling \
                test_full_gc_ownership_handoff \
                test_defer_free \
                test_proto_gen \
-               test_proto_desc
+               test_proto_desc \
+               test_html_builder
 
 .PHONY: all test $(TEST_TARGETS) fuzz_seq install uninstall dist clean rebuild examples clean-examples wasm wasm-smoke clean-wasm
 
@@ -1028,3 +1029,8 @@ test_proto_desc: $(LIB_NAME) tests/test_proto_gen.c tests/make_sample_descriptor
 	diff tests/test_proto_gen_sample.cwist.pb.h tests/test_proto_gen_desc_sample.cwist.pb.h
 	$(CC) $(CFLAGS) -Itests -DPROTO_GEN_SAMPLE_HEADER='"test_proto_gen_desc_sample.cwist.pb.h"' -o test_proto_desc tests/test_proto_gen.c $(LIB_NAME) $(LIBS)
 	./test_proto_desc
+
+test_html_builder: $(LIB_NAME) tests/test_html_builder.c
+	$(CC) $(CFLAGS) -o test_html_builder tests/test_html_builder.c $(LIB_NAME) $(LIBS)
+	./test_html_builder
+

--- a/src/core/html/builder.c
+++ b/src/core/html/builder.c
@@ -21,7 +21,7 @@ cwist_html_element_t* cwist_html_element_create(const char *tag) {
     if (!el) return NULL;
     
     el->tag = cwist_sstring_create();
-    cwist_sstring_assign(el->tag, (char*)tag);
+    cwist_sstring_assign(el->tag, tag ? tag : "");
     el->attributes = cJSON_CreateObject();
     el->children = NULL;
     el->child_count = 0;
@@ -59,7 +59,7 @@ void cwist_html_element_destroy(cwist_html_element_t *el) {
  * @param value Attribute value stored as a cJSON string node.
  */
 void cwist_html_element_add_attr(cwist_html_element_t *el, const char *key, const char *value) {
-    if (!el || !key || !value) return;
+    if (!el || !key || !value || !el->attributes) return;
     
     if (cJSON_HasObjectItem(el->attributes, key)) {
         cJSON_ReplaceItemInObject(el->attributes, key, cJSON_CreateString(value));
@@ -83,16 +83,16 @@ void cwist_html_element_set_id(cwist_html_element_t *el, const char *id) {
  * @param class_name Class token to append or initialise.
  */
 void cwist_html_element_add_class(cwist_html_element_t *el, const char *class_name) {
-    if (!el || !class_name) return;
+    if (!el || !class_name || !el->attributes) return;
     
     cJSON *cls = cJSON_GetObjectItem(el->attributes, "class");
-    if (cls) {
+    if (cls && cls->valuestring && *cls->valuestring) {
         // Append to existing class
         cwist_sstring *s = cwist_sstring_create();
         cwist_sstring_assign(s, cls->valuestring);
         cwist_sstring_append(s, " ");
         cwist_sstring_append(s, class_name);
-        cJSON_ReplaceItemInObject(el->attributes, "class", cJSON_CreateString(s->data));
+        cJSON_ReplaceItemInObject(el->attributes, "class", cJSON_CreateString(s->data ? s->data : ""));
         cwist_sstring_destroy(s);
     } else {
         cwist_html_element_add_attr(el, "class", class_name);
@@ -106,11 +106,12 @@ void cwist_html_element_add_class(cwist_html_element_t *el, const char *class_na
  */
 void cwist_html_element_set_text(cwist_html_element_t *el, const char *text) {
     if (!el) return;
+    const char *actual_text = text ? text : "";
     if (el->inner_text) {
-        cwist_sstring_assign(el->inner_text, (char*)text);
+        cwist_sstring_assign(el->inner_text, actual_text);
     } else {
         el->inner_text = cwist_sstring_create();
-        cwist_sstring_assign(el->inner_text, (char*)text);
+        cwist_sstring_assign(el->inner_text, actual_text);
     }
 }
 
@@ -138,23 +139,37 @@ void cwist_html_element_add_child(cwist_html_element_t *el, cwist_html_element_t
  * @param out Destination buffer that receives generated markup.
  */
 static void render_element(cwist_html_element_t *el, cwist_sstring *out) {
-    if (!el) return;
+    if (!el || !out) return;
     
     if (el->tag && el->tag->data && *el->tag->data) {
         cwist_sstring_append(out, "<");
         cwist_sstring_append(out, el->tag->data);
         cJSON *attr = NULL;
         cJSON_ArrayForEach(attr, el->attributes) {
-            cwist_sstring_append(out, " ");
-            cwist_sstring_append(out, attr->string);
-            cwist_sstring_append(out, "=\"");
-            cwist_sstring_append(out, attr->valuestring);
-            cwist_sstring_append(out, "\"");
+            if (!attr || !attr->string) continue;
+            if (cJSON_IsString(attr) && attr->valuestring) {
+                cwist_sstring_append(out, " ");
+                cwist_sstring_append(out, attr->string);
+                cwist_sstring_append(out, "=\"");
+                cwist_sstring_append_escaped(out, attr->valuestring);
+                cwist_sstring_append(out, "\"");
+            } else if (cJSON_IsTrue(attr)) {
+                cwist_sstring_append(out, " ");
+                cwist_sstring_append(out, attr->string);
+            } else if (cJSON_IsNumber(attr)) {
+                char num_buf[64];
+                snprintf(num_buf, sizeof(num_buf), "%g", attr->valuedouble);
+                cwist_sstring_append(out, " ");
+                cwist_sstring_append(out, attr->string);
+                cwist_sstring_append(out, "=\"");
+                cwist_sstring_append(out, num_buf);
+                cwist_sstring_append(out, "\"");
+            }
         }
         cwist_sstring_append(out, ">");
         
         if (el->inner_text && el->inner_text->data) {
-            cwist_sstring_append(out, el->inner_text->data);
+            cwist_sstring_append_escaped(out, el->inner_text->data);
         }
         
         if (el->children) {

--- a/tests/test_html_builder.c
+++ b/tests/test_html_builder.c
@@ -1,0 +1,97 @@
+#include <cwist/core/html/builder.h>
+#include <cwist/core/sstring/sstring.h>
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+
+void test_basic_element(void) {
+    cwist_html_element_t *div = cwist_html_element_create("div");
+    assert(div != NULL);
+    cwist_html_element_add_attr(div, "id", "container");
+    cwist_html_element_add_class(div, "main-box");
+    cwist_html_element_set_text(div, "Hello World");
+
+    cwist_sstring *rendered = cwist_html_render(div);
+    assert(rendered != NULL && rendered->data != NULL);
+    assert(strstr(rendered->data, "<div") != NULL);
+    assert(strstr(rendered->data, "id=\"container\"") != NULL);
+    assert(strstr(rendered->data, "class=\"main-box\"") != NULL);
+    assert(strstr(rendered->data, ">Hello World</div>") != NULL);
+
+    cwist_sstring_destroy(rendered);
+    cwist_html_element_destroy(div);
+    printf("Passed test_basic_element\n");
+}
+
+void test_attribute_escaping(void) {
+    cwist_html_element_t *input = cwist_html_element_create("input");
+    assert(input != NULL);
+    /* Attribute value containing quotes and special chars */
+    cwist_html_element_add_attr(input, "value", "attack\" onclick=\"evil()\" & 'more'");
+    cwist_html_element_add_attr(input, "name", "safe_name");
+
+    cwist_sstring *rendered = cwist_html_render(input);
+    assert(rendered != NULL && rendered->data != NULL);
+    /* Should NOT contain raw unescaped quotes inside value */
+    assert(strstr(rendered->data, "attack&quot; onclick=&quot;evil()&quot; &amp; &#39;more&#39;") != NULL);
+
+    cwist_sstring_destroy(rendered);
+    cwist_html_element_destroy(input);
+    printf("Passed test_attribute_escaping\n");
+}
+
+void test_boolean_and_numeric_attributes(void) {
+    cwist_html_element_t *btn = cwist_html_element_create("button");
+    assert(btn != NULL);
+    cJSON_AddTrueToObject(btn->attributes, "disabled");
+    cJSON_AddNumberToObject(btn->attributes, "tabindex", 2);
+
+    cwist_sstring *rendered = cwist_html_render(btn);
+    assert(rendered != NULL && rendered->data != NULL);
+    assert(strstr(rendered->data, " disabled") != NULL);
+    assert(strstr(rendered->data, "tabindex=\"2\"") != NULL);
+
+    cwist_sstring_destroy(rendered);
+    cwist_html_element_destroy(btn);
+    printf("Passed test_boolean_and_numeric_attributes\n");
+}
+
+void test_nested_children_and_null_safety(void) {
+    /* Null safety */
+    assert(cwist_html_render(NULL) == NULL);
+    cwist_html_element_destroy(NULL);
+    cwist_html_element_add_attr(NULL, "k", "v");
+    cwist_html_element_set_id(NULL, "id");
+    cwist_html_element_add_class(NULL, "cls");
+    cwist_html_element_set_text(NULL, "txt");
+    cwist_html_element_add_child(NULL, NULL);
+
+    /* Nested tree */
+    cwist_html_element_t *parent = cwist_html_element_create("ul");
+    cwist_html_element_t *li1 = cwist_html_element_create("li");
+    cwist_html_element_set_text(li1, "Item 1 & 2");
+    cwist_html_element_t *li2 = cwist_html_element_create("li");
+    cwist_html_element_set_text(li2, "Item 3");
+
+    cwist_html_element_add_child(parent, li1);
+    cwist_html_element_add_child(parent, li2);
+
+    cwist_sstring *rendered = cwist_html_render(parent);
+    assert(rendered != NULL && rendered->data != NULL);
+    assert(strstr(rendered->data, "<li>Item 1 &amp; 2</li>") != NULL);
+    assert(strstr(rendered->data, "<li>Item 3</li>") != NULL);
+    assert(strstr(rendered->data, "</ul>") != NULL);
+
+    cwist_sstring_destroy(rendered);
+    cwist_html_element_destroy(parent);
+    printf("Passed test_nested_children_and_null_safety\n");
+}
+
+int main(void) {
+    test_basic_element();
+    test_attribute_escaping();
+    test_boolean_and_numeric_attributes();
+    test_nested_children_and_null_safety();
+    printf("All HTML builder tests passed!\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
This PR fixes XSS / attribute injection vulnerabilities and adds safe handling of boolean, numeric, and null attributes in `cwist_html_builder`:

1. **HTML attribute value escaping**:
   - `render_element()` previously emitted attribute values directly via `cwist_sstring_append(out, attr->valuestring)`.
   - Any attribute containing `"` (double quotes), `<`, `>`, or `&` would break out of the HTML attribute quotes or produce invalid/vulnerable markup.
   - Now, attribute string values are safely escaped with `cwist_sstring_append_escaped()`.

2. **Safe handling of non-string and boolean attributes**:
   - In HTML, attributes can be boolean flags (e.g. `disabled`, `checked`, `readonly`) or numeric (e.g. `tabindex="2"`).
   - If a non-string cJSON item was added to `el->attributes`, `attr->valuestring` was NULL, leading to empty/malformed rendering.
   - Handled `cJSON_IsTrue(attr)` to emit standard boolean HTML attributes (` disabled`).
   - Handled `cJSON_IsNumber(attr)` to serialize double/integer values (` tabindex="2"`).

3. **Escaping inner text and null safety**:
   - Ensured element `inner_text` is escaped with `cwist_sstring_append_escaped()`.
   - Added null guards in `cwist_html_element_create()`, `cwist_html_element_add_attr()`, `cwist_html_element_add_class()`, `cwist_html_element_set_text()`, and `render_element()`.

4. **Tests & Build integration**:
   - Added `tests/test_html_builder.c` covering elements, class handling, attribute escaping, boolean/numeric attributes, nested children, and null safety.
   - Added `test_html_builder` to `Makefile`.

## Testing
- Successfully compiled and ran `tests/test_html_builder.c` under WSL/Linux. All assertions passed. Target branch: `dev`.
