### PR TITLE
fix(grpc): check buffered append errors by active type

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -499,6 +499,7 @@ TEST_TARGETS = test_classic_pool_scaling \
                test_test_client \
                test_multiport \
                test_grpc \
+               test_grpc_append_error \
                test_grpc_stream \
                test_grpc_client \
                test_grpc_channel \
@@ -964,6 +965,10 @@ test_multiport: $(LIB_NAME) tests/test_multiport.c
 test_grpc: $(LIB_NAME) tests/test_grpc.c
 	$(CC) $(CFLAGS) -o test_grpc tests/test_grpc.c $(LIB_NAME) $(LIBS)
 	./test_grpc
+
+test_grpc_append_error: $(LIB_NAME) tests/test_grpc_append_error.c
+	$(CC) $(CFLAGS) -o test_grpc_append_error tests/test_grpc_append_error.c $(LIB_NAME) $(LIBS)
+	./test_grpc_append_error
 
 test_grpc_stream: $(LIB_NAME) tests/test_grpc_stream.c
 	$(CC) $(CFLAGS) -o test_grpc_stream tests/test_grpc_stream.c $(LIB_NAME) $(LIBS)

--- a/src/net/grpc/grpc.c
+++ b/src/net/grpc/grpc.c
@@ -696,7 +696,9 @@ int cwist_grpc_stream_send(cwist_grpc_stream *stream,
     }
     cwist_error_t err = cwist_sstring_append_len(stream->res->body, (char *)frame, frame_len);
     cwist_free(frame);
-    if (err.error.err_i16 != 0) {
+    bool appended = cwist_error_is_ok(&err);
+    cwist_error_dispose(&err);
+    if (!appended) {
         stream->status = CWIST_GRPC_INTERNAL;
         stream->status_message = "failed to append gRPC stream message";
         return -1;

--- a/tests/test_grpc.c
+++ b/tests/test_grpc.c
@@ -240,7 +240,8 @@ static void append_grpc_string_frame(cwist_sstring *body, const char *value) {
     uint8_t *frame = NULL;
     size_t frame_len = 0;
     assert(cwist_grpc_encode_message(pb.data, pb.len, 0, &frame, &frame_len) == 0);
-    assert(cwist_sstring_append_len(body, (char *)frame, frame_len).error.err_i16 == 0);
+    cwist_error_t append_err = cwist_sstring_append_len(body, (char *)frame, frame_len);
+    assert(cwist_error_is_ok(&append_err));
 
     cwist_free(frame);
     cwist_pb_writer_free(&pb);

--- a/tests/test_grpc_append_error.c
+++ b/tests/test_grpc_append_error.c
@@ -1,0 +1,114 @@
+#define _POSIX_C_SOURCE 200809L
+#include <cwist/net/grpc/grpc.h>
+#include <cwist/core/mem/alloc.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define REQUIRE(expr) do { \
+    if (!(expr)) { \
+        fprintf(stderr, "Check failed at %s:%d: %s\n", __FILE__, __LINE__, #expr); \
+        exit(1); \
+    } \
+} while (0)
+
+static int fail_append;
+static int allocation_failures;
+static int disposed_json;
+static void *body_pointer;
+static size_t failed_size;
+
+static cwist_error_t test_make_error(cwist_errtype_t type) {
+    cwist_error_t err = { .errtype = type };
+    /* Only the producer's active field has meaning. */
+    err.error.err_i16 = fail_append ? 0 : 17;
+    return err;
+}
+
+static void *test_realloc(void *pointer, size_t size) {
+    if (fail_append && pointer == body_pointer && size == failed_size) {
+        allocation_failures++;
+        return NULL;
+    }
+    return cwist_realloc(pointer, size);
+}
+
+#define make_error test_make_error
+#define cwist_realloc test_realloc
+#include "../src/core/sstring/sstring.c"
+#undef cwist_realloc
+#undef make_error
+
+static void test_dispose(cwist_error_t *err) {
+    if (err && err->errtype == CWIST_ERR_JSON && err->error.err_json) {
+        disposed_json++;
+    }
+    cwist_error_dispose(err);
+}
+
+#define cwist_error_dispose test_dispose
+#include "../src/net/grpc/grpc.c"
+#undef cwist_error_dispose
+
+static void check_success(void) {
+    fail_append = 0;
+    cwist_sstring *body = cwist_sstring_create();
+    REQUIRE(body != NULL);
+    cwist_http_response response = { .body = body };
+    cwist_grpc_stream stream = { .res = &response, .status = CWIST_GRPC_OK };
+    const unsigned char payload[] = { 'a', 0, 'b' };
+    const unsigned char expected[] = {
+        0, 0, 0, 0, 3, 'a', 0, 'b',
+        0, 0, 0, 0, 1, 'z',
+        0, 0, 0, 0, 0
+    };
+    int rc = cwist_grpc_stream_send(&stream, payload, sizeof(payload));
+    REQUIRE(rc == 0);
+    REQUIRE(cwist_grpc_stream_send(&stream, "z", 1) == 0);
+    REQUIRE(cwist_grpc_stream_send(&stream, NULL, 0) == 0);
+    REQUIRE(stream.status == CWIST_GRPC_OK);
+    REQUIRE(body->size == sizeof(expected));
+    REQUIRE(memcmp(body->data, expected, sizeof(expected)) == 0);
+    cwist_sstring_destroy(body);
+}
+
+static void check_append_failure(void) {
+    fail_append = 0;
+    allocation_failures = 0;
+    disposed_json = 0;
+    cwist_sstring *body = cwist_sstring_create();
+    REQUIRE(body != NULL);
+    cwist_error_t initial = cwist_sstring_append_len(body, "old", 3);
+    REQUIRE(cwist_error_is_ok(&initial));
+    cwist_http_response response = { .body = body };
+    cwist_grpc_stream stream = { .res = &response, .status = CWIST_GRPC_OK };
+    body_pointer = body->data;
+    failed_size = body->size + 5 + 3 + 1;
+    fail_append = 1;
+    int result = cwist_grpc_stream_send(&stream, "abc", 3);
+    fail_append = 0;
+    REQUIRE(allocation_failures == 1);
+    REQUIRE(result == -1);
+    REQUIRE(stream.status == CWIST_GRPC_INTERNAL);
+    REQUIRE(strcmp(stream.status_message, "failed to append gRPC stream message") == 0);
+    REQUIRE(body->data == body_pointer);
+    REQUIRE(body->size == 3);
+    REQUIRE(memcmp(body->data, "old", 3) == 0);
+    REQUIRE(disposed_json == 1);
+    cwist_sstring_destroy(body);
+}
+
+int main(int argc, char **argv) {
+    (void)test_dispose;
+    if (argc == 2) {
+        REQUIRE(strcmp(argv[1], "json") == 0);
+        check_append_failure();
+    } else {
+        REQUIRE(argc == 1);
+        check_success();
+        check_append_failure();
+        check_success();
+    }
+    puts("gRPC append error checks passed");
+    return 0;
+}


### PR DESCRIPTION
## Summary

Found while validating #25. This fixes buffered gRPC correctness; it does **not** claim a plain-HTTP tail-latency improvement.

`cwist_sstring_append_len` returns INT8 on success and a JSON error when buffer growth fails. `cwist_grpc_stream_send` checked the unrelated INT16 field. The payload is a struct, and the constructor initializes only its tag, so that field is indeterminate.

- Check the active error type with `cwist_error_is_ok`.
- Dispose the consumed JSON error after saving the success result.
- Fix the same incorrect field check in the existing gRPC test helper.
- Add a portable regression target covering correct binary/empty frames and real append-allocation failure.

The regression compiles the real gRPC and string code. Its narrow realloc seam fails only the response body's expected growth allocation. It checks INTERNAL status, unchanged original body, and disposal of the actual JSON error. An initialized test-only constructor makes the inactive-field bug deterministic in both directions.

## Validation

Tested on ARM64 Linux, GCC, source base `b37f974a3eb2df1d753d46e408e04a83004f4b03`. The four tested guest files match the independently reviewed staged blobs by SHA-256.

- Original code + new regression: fails successful append (`rc == 0`).
- Original code + real allocation failure: fails error propagation (`result == -1`).
- Corrected existing `test_grpc` helper against the old library also reproduces failure in `echo_stream`.
- Fixed: all five gRPC targets pass with `WERROR=1` normally and with ASan/UBSan, after rebuilding framework objects for the sanitizer flags.
- New regression also passes with `-DNDEBUG`, normally and with ASan/UBSan.
- Full serial `CWIST_WORKERS=1 make WERROR=1 test`: **60/60 targets pass**.
- Independent four-file review: approved, no blocking findings.

## Limits / retained failures

- An earlier full parallel `make -k -j4 WERROR=1 test` failed the existing `test_grpc_stream.c:410` deadline assertion (`cancelled_seen`). Targeted normal/sanitizer runs and the full serial run pass. This PR does not claim that parallel-suite failure is fixed.
- The test driver for the first RED run ended on a stale expected-log-string assertion. Both actual regression executions compiled and failed at the intended behavioral checks; their logs were verified separately. Do not count the driver's exit as a green gate.
- The existing `stress_test` can leave prefork children alive. The task-owned remnants were cleaned up; the serial suite uses one worker to avoid that harness problem. No stress-test lifecycle change is bundled here.
- Session-backed gRPC writes, public ABI, and the error producer itself are unchanged. In particular, reserve failure followed by failure to allocate the JSON error object remains a separate producer issue; this is not comprehensive OOM hardening.
- CI on the proposed merge tree is still required. No P99.999 resolution claim.
