### PR TITLE
fix(bind): fix cJSON memory leak and add null guards in validation rules

### DIFF
--- a/src/core/validation/bind.c
+++ b/src/core/validation/bind.c
@@ -85,9 +85,13 @@ static bool check_rule(const cwist_bind_rule_t *rule,
             break;
 
         case CWIST_BIND_RULE_MIN_VAL: {
+            char *end = NULL;
             long double v = 0.0L;
-            if (value) v = strtold(value, NULL);
-            if (!value || v < rule->u.min_val) {
+            if (value && *value) {
+                errno = 0;
+                v = strtold(value, &end);
+            }
+            if (!value || !end || end == value || *end != '\0' || errno == ERANGE || v < rule->u.min_val) {
                 snprintf(buf, sizeof(buf), "%s: minimum value is %Lg",
                          rule->error_message ? rule->error_message : "value too small",
                          rule->u.min_val);
@@ -98,9 +102,13 @@ static bool check_rule(const cwist_bind_rule_t *rule,
         }
 
         case CWIST_BIND_RULE_MAX_VAL: {
+            char *end = NULL;
             long double v = 0.0L;
-            if (value) v = strtold(value, NULL);
-            if (!value || v > rule->u.max_val) {
+            if (value && *value) {
+                errno = 0;
+                v = strtold(value, &end);
+            }
+            if (!value || !end || end == value || *end != '\0' || errno == ERANGE || v > rule->u.max_val) {
                 snprintf(buf, sizeof(buf), "%s: maximum value is %Lg",
                          rule->error_message ? rule->error_message : "value too large",
                          rule->u.max_val);
@@ -113,6 +121,10 @@ static bool check_rule(const cwist_bind_rule_t *rule,
         case CWIST_BIND_RULE_REGEX: {
             if (!value) {
                 bind_add_error(r, key, "missing value for regex check");
+                return false;
+            }
+            if (!rule->u.pattern) {
+                bind_add_error(r, key, "invalid regex pattern");
                 return false;
             }
             regex_t re;
@@ -142,7 +154,7 @@ static bool check_rule(const cwist_bind_rule_t *rule,
             break;
 
         case CWIST_BIND_RULE_CUSTOM:
-            if (!value || !rule->u.custom.fn(value, len, rule->u.custom.ctx)) {
+            if (!rule->u.custom.fn || !value || !rule->u.custom.fn(value, len, rule->u.custom.ctx)) {
                 snprintf(buf, sizeof(buf), "%s",
                          rule->error_message ? rule->error_message : "custom validation failed");
                 bind_add_error(r, key, buf);
@@ -324,6 +336,7 @@ static bool cwist_bind_generic(const cwist_bind_schema_t *schema,
     for (size_t i = 0; i < schema->field_count; ++i) {
         const cwist_bind_field_t *f = &schema->fields[i];
         const char *raw_value = NULL;
+        char *allocated_json = NULL;
 
         if (is_json && root) {
             const cJSON *item = cJSON_GetObjectItemCaseSensitive(root, f->json_key);
@@ -345,17 +358,8 @@ static bool cwist_bind_generic(const cwist_bind_schema_t *schema,
                 } else if (cJSON_IsNull(item)) {
                     raw_value = NULL;
                 } else if (cJSON_IsObject(item) || cJSON_IsArray(item)) {
-                    /* For JSON_OBJECT targets, serialise the subtree */
-                    if (f->target_type == CWIST_BIND_JSON_OBJECT) {
-                        char *printed = cJSON_PrintUnformatted(item);
-                        raw_value = printed; /* transient; written below */
-                        write_value(f, raw_value, out, result);
-                        free(printed);
-                        continue;
-                    } else {
-                        raw_value = cJSON_PrintUnformatted(item);
-                        /* fall through to string validation then cleanup */
-                    }
+                    allocated_json = cJSON_PrintUnformatted(item);
+                    raw_value = allocated_json;
                 }
             }
         } else {
@@ -400,7 +404,10 @@ static bool cwist_bind_generic(const cwist_bind_schema_t *schema,
         }
 
         /* Clean up temporary printed JSON if we allocated one above */
-        if (!is_json) { /* already handled */ }
+        if (allocated_json) {
+            cJSON_free(allocated_json);
+            allocated_json = NULL;
+        }
     }
 
     if (root) cJSON_Delete(root);

--- a/tests/test_bind.c
+++ b/tests/test_bind.c
@@ -177,6 +177,53 @@ void test_bind_regex(void) {
     printf("  OK\n");
 }
 
+void test_bind_null_guards_and_numeric_validation(void) {
+    printf("test_bind_null_guards_and_numeric_validation...\n");
+    /* 1. Non-numeric value for numeric rule */
+    const char *json_nan = "{\"email\":\"test@example.com\",\"age\":\"notanumber\",\"name\":\"Test\",\"score\":50.0}";
+    cwist_http_request *req = cwist_http_request_create();
+    cwist_sstring_assign(req->body, (char *)json_nan);
+    user_t out;
+    memset(&out, 0, sizeof(out));
+    cwist_bind_result_t result;
+    bool ok = cwist_app_req_bind_json(req, &user_schema, &out, &result);
+    assert(ok == false);
+    assert(result.error_count > 0);
+    cwist_http_request_destroy(req);
+
+    /* 2. NULL pattern regex rule safety */
+    typedef struct { char val[16]; } null_re_t;
+    CWIST_BIND_RULES(null_re_rules, CWIST_RULE_REGEX(NULL));
+    static const cwist_bind_field_t null_re_fields[] = {
+        CWIST_BIND_FIELD(null_re_t, val, "val", null_re_rules),
+    };
+    static const cwist_bind_schema_t null_re_schema = CWIST_BIND_SCHEMA(null_re_t, null_re_fields);
+    req = cwist_http_request_create();
+    cwist_sstring_assign(req->body, "{\"val\":\"abc\"}");
+    null_re_t out_re;
+    memset(&out_re, 0, sizeof(out_re));
+    ok = cwist_app_req_bind_json(req, &null_re_schema, &out_re, &result);
+    assert(ok == false);
+    cwist_http_request_destroy(req);
+
+    /* 3. NULL custom callback rule safety */
+    typedef struct { char val[16]; } null_custom_t;
+    CWIST_BIND_RULES(null_custom_rules, CWIST_RULE_CUSTOM(NULL, NULL));
+    static const cwist_bind_field_t null_custom_fields[] = {
+        CWIST_BIND_FIELD(null_custom_t, val, "val", null_custom_rules),
+    };
+    static const cwist_bind_schema_t null_custom_schema = CWIST_BIND_SCHEMA(null_custom_t, null_custom_fields);
+    req = cwist_http_request_create();
+    cwist_sstring_assign(req->body, "{\"val\":\"abc\"}");
+    null_custom_t out_custom;
+    memset(&out_custom, 0, sizeof(out_custom));
+    ok = cwist_app_req_bind_json(req, &null_custom_schema, &out_custom, &result);
+    assert(ok == false);
+    cwist_http_request_destroy(req);
+
+    printf("  OK\n");
+}
+
 int main(void) {
     test_bind_success();
     test_bind_missing_required();
@@ -185,6 +232,8 @@ int main(void) {
     test_bind_auto_400_response();
     test_bind_form_data();
     test_bind_regex();
+    test_bind_null_guards_and_numeric_validation();
     printf("All bind tests passed.\n");
     return 0;
 }
+


### PR DESCRIPTION
## Summary
This PR fixes a heap memory leak and several edge-case NULL dereferences and validation flaws in `cwist_bind`:

1. **Fix `cJSON_PrintUnformatted()` heap memory leak**:
   - In `cwist_bind_generic()`, when handling JSON objects or arrays, `cJSON_PrintUnformatted(item)` was allocated into `raw_value`.
   - The memory was never freed, leaking heap memory on every request binding an object or array.
   - Now tracks `allocated_json` and ensures it is freed via `cJSON_free()`.
   - Also ensures validation rules are run for all object fields rather than prematurely skipping them with `continue`.

2. **NULL safety in validation rules**:
   - In `CWIST_BIND_RULE_REGEX`: validates `rule->u.pattern != NULL` before invoking `regcomp()`, preventing segfaults on malformed rule definitions.
   - In `CWIST_BIND_RULE_CUSTOM`: validates `rule->u.custom.fn != NULL` before calling the function pointer, preventing NULL function pointer dereference crashes.

3. **Strict numeric parsing in `MIN_VAL` and `MAX_VAL`**:
   - Previously `strtold(value, NULL)` was called without checking `endptr`. Non-numeric inputs like `"notanumber"` returned `0.0L` and erroneously passed validation if 0 fell within the valid range.
   - Now properly checks `end == value`, `*end != '\0'`, and `errno == ERANGE`.

4. **Tests**:
   - Added `test_bind_null_guards_and_numeric_validation()` in `tests/test_bind.c` testing non-numeric input rejection, NULL regex pattern safety, and NULL custom callback safety.

## Testing
- Tested and passed unit test suite under GCC/WSL. Target branch: `dev`.
