### PR TITLE
fix(json_builder): escape strings per RFC 8259 and add null safety

### DIFF
--- a/src/core/utils/json_builder.c
+++ b/src/core/utils/json_builder.c
@@ -3,6 +3,7 @@
 #include <cwist/core/mem/alloc.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
 
 /**
  * @file json_builder.c
@@ -21,6 +22,10 @@ cwist_json_builder *cwist_json_builder_create(void) {
     cwist_json_builder *b = (cwist_json_builder *)cwist_alloc(sizeof(cwist_json_builder));
     if (!b) return NULL;
     b->buffer = cwist_sstring_create();
+    if (!b->buffer) {
+        cwist_free(b);
+        return NULL;
+    }
     b->needs_comma = false;
     return b;
 }
@@ -31,18 +36,70 @@ cwist_json_builder *cwist_json_builder_create(void) {
  */
 void cwist_json_builder_destroy(cwist_json_builder *b) {
     if (b) {
-        cwist_sstring_destroy(b->buffer);
+        if (b->buffer) {
+            cwist_sstring_destroy(b->buffer);
+        }
         cwist_free(b);
     }
 }
 
-/**
- * @brief Insert a comma when the previous operation emitted a complete value.
- * @param b Builder being updated.
- */
 static void append_comma_if_needed(cwist_json_builder *b) {
-    if (b->needs_comma) {
+    if (b && b->buffer && b->needs_comma) {
         cwist_sstring_append(b->buffer, ",");
+    }
+}
+
+static void append_json_escaped_str(cwist_sstring *buf, const char *str) {
+    if (!str) return;
+    cwist_sstring_append(buf, "\"");
+    const char *start = str;
+    const char *p = str;
+    while (*p) {
+        const char *esc = NULL;
+        char ucode[8];
+        switch (*p) {
+            case '"':  esc = "\\\""; break;
+            case '\\': esc = "\\\\"; break;
+            case '\b': esc = "\\b";  break;
+            case '\f': esc = "\\f";  break;
+            case '\n': esc = "\\n";  break;
+            case '\r': esc = "\\r";  break;
+            case '\t': esc = "\\t";  break;
+            default:
+                if ((unsigned char)*p < 0x20) {
+                    snprintf(ucode, sizeof(ucode), "\\u%04x", (unsigned char)*p);
+                    esc = ucode;
+                }
+                break;
+        }
+        if (esc) {
+            if (p > start) {
+                char tmp[4096];
+                size_t seg_len = (size_t)(p - start);
+                while (seg_len > 0) {
+                    size_t chunk = seg_len < sizeof(tmp) - 1 ? seg_len : sizeof(tmp) - 1;
+                    memcpy(tmp, start, chunk);
+                    tmp[chunk] = '\0';
+                    cwist_sstring_append(buf, tmp);
+                    start += chunk;
+                    seg_len -= chunk;
+                }
+            }
+            cwist_sstring_append(buf, esc);
+            start = p + 1;
+        }
+        p++;
+    }
+    if (p > start) {
+        cwist_sstring_append(buf, start);
+    }
+    cwist_sstring_append(buf, "\"");
+}
+
+static void append_key_if_present(cwist_json_builder *b, const char *key) {
+    if (key) {
+        append_json_escaped_str(b->buffer, key);
+        cwist_sstring_append(b->buffer, ":");
     }
 }
 
@@ -51,7 +108,7 @@ static void append_comma_if_needed(cwist_json_builder *b) {
  * @param b Builder to update. NULL is ignored.
  */
 void cwist_json_begin_object(cwist_json_builder *b) {
-    if (!b) return;
+    if (!b || !b->buffer) return;
     append_comma_if_needed(b);
     cwist_sstring_append(b->buffer, "{");
     b->needs_comma = false;
@@ -62,7 +119,7 @@ void cwist_json_begin_object(cwist_json_builder *b) {
  * @param b Builder to update. NULL is ignored.
  */
 void cwist_json_end_object(cwist_json_builder *b) {
-    if (!b) return;
+    if (!b || !b->buffer) return;
     cwist_sstring_append(b->buffer, "}");
     b->needs_comma = true;
 }
@@ -73,12 +130,11 @@ void cwist_json_end_object(cwist_json_builder *b) {
  * @param key Object member name, or NULL when emitting a bare array value.
  */
 void cwist_json_begin_array(cwist_json_builder *b, const char *key) {
-    if (!b) return;
+    if (!b || !b->buffer) return;
     append_comma_if_needed(b);
     if (key) {
-        cwist_sstring_append(b->buffer, "\"");
-        cwist_sstring_append(b->buffer, (char*)key);
-        cwist_sstring_append(b->buffer, "\":[");
+        append_json_escaped_str(b->buffer, key);
+        cwist_sstring_append(b->buffer, ":[");
     } else {
         cwist_sstring_append(b->buffer, "[");
     }
@@ -90,7 +146,7 @@ void cwist_json_begin_array(cwist_json_builder *b, const char *key) {
  * @param b Builder to update. NULL is ignored.
  */
 void cwist_json_end_array(cwist_json_builder *b) {
-    if (!b) return;
+    if (!b || !b->buffer) return;
     cwist_sstring_append(b->buffer, "]");
     b->needs_comma = true;
 }
@@ -102,16 +158,14 @@ void cwist_json_end_array(cwist_json_builder *b) {
  * @param value String payload to emit verbatim between quotes.
  */
 void cwist_json_add_string(cwist_json_builder *b, const char *key, const char *value) {
-    if (!b) return;
+    if (!b || !b->buffer) return;
     append_comma_if_needed(b);
-    if (key) {
-        cwist_sstring_append(b->buffer, "\"");
-        cwist_sstring_append(b->buffer, (char*)key);
-        cwist_sstring_append(b->buffer, "\":");
+    append_key_if_present(b, key);
+    if (value) {
+        append_json_escaped_str(b->buffer, value);
+    } else {
+        cwist_sstring_append(b->buffer, "null");
     }
-    cwist_sstring_append(b->buffer, "\"");
-    cwist_sstring_append(b->buffer, (char*)value);
-    cwist_sstring_append(b->buffer, "\"");
     b->needs_comma = true;
 }
 
@@ -122,13 +176,9 @@ void cwist_json_add_string(cwist_json_builder *b, const char *key, const char *v
  * @param value Integer payload to format in base 10.
  */
 void cwist_json_add_int(cwist_json_builder *b, const char *key, int value) {
-    if (!b) return;
+    if (!b || !b->buffer) return;
     append_comma_if_needed(b);
-    if (key) {
-        cwist_sstring_append(b->buffer, "\"");
-        cwist_sstring_append(b->buffer, (char*)key);
-        cwist_sstring_append(b->buffer, "\":");
-    }
+    append_key_if_present(b, key);
     char buf[32];
     snprintf(buf, sizeof(buf), "%d", value);
     cwist_sstring_append(b->buffer, buf);
@@ -142,13 +192,9 @@ void cwist_json_add_int(cwist_json_builder *b, const char *key, int value) {
  * @param value Boolean payload to serialise as true or false.
  */
 void cwist_json_add_bool(cwist_json_builder *b, const char *key, bool value) {
-    if (!b) return;
+    if (!b || !b->buffer) return;
     append_comma_if_needed(b);
-    if (key) {
-        cwist_sstring_append(b->buffer, "\"");
-        cwist_sstring_append(b->buffer, (char*)key);
-        cwist_sstring_append(b->buffer, "\":");
-    }
+    append_key_if_present(b, key);
     cwist_sstring_append(b->buffer, value ? "true" : "false");
     b->needs_comma = true;
 }
@@ -159,13 +205,9 @@ void cwist_json_add_bool(cwist_json_builder *b, const char *key, bool value) {
  * @param key Object member name, or NULL when appending an array element.
  */
 void cwist_json_add_null(cwist_json_builder *b, const char *key) {
-    if (!b) return;
+    if (!b || !b->buffer) return;
     append_comma_if_needed(b);
-    if (key) {
-        cwist_sstring_append(b->buffer, "\"");
-        cwist_sstring_append(b->buffer, (char*)key);
-        cwist_sstring_append(b->buffer, "\":");
-    }
+    append_key_if_present(b, key);
     cwist_sstring_append(b->buffer, "null");
     b->needs_comma = true;
 }

--- a/tests/test_json_builder.c
+++ b/tests/test_json_builder.c
@@ -1,0 +1,117 @@
+/**
+ * @file test_json_builder.c
+ * @brief Unit tests for JSON builder string escaping, NULL guards, and formatting.
+ */
+
+#include <cwist/core/utils/json_builder.h>
+#include <cjson/cJSON.h>
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+
+static void test_json_builder_null_guards(void) {
+    printf("test_json_builder_null_guards...\n");
+    cwist_json_builder_destroy(NULL);
+    cwist_json_begin_object(NULL);
+    cwist_json_end_object(NULL);
+    cwist_json_begin_array(NULL, "arr");
+    cwist_json_end_array(NULL);
+    cwist_json_add_string(NULL, "k", "v");
+    cwist_json_add_int(NULL, "k", 10);
+    cwist_json_add_bool(NULL, "k", true);
+    cwist_json_add_null(NULL, "k");
+    assert(cwist_json_get_raw(NULL) == NULL);
+}
+
+static void test_json_builder_basic(void) {
+    printf("test_json_builder_basic...\n");
+    cwist_json_builder *b = cwist_json_builder_create();
+    assert(b != NULL);
+
+    cwist_json_begin_object(b);
+    cwist_json_add_string(b, "name", "Alice");
+    cwist_json_add_int(b, "age", 30);
+    cwist_json_add_bool(b, "active", true);
+    cwist_json_add_null(b, "nickname");
+    cwist_json_end_object(b);
+
+    const char *raw = cwist_json_get_raw(b);
+    assert(raw != NULL);
+    assert(strcmp(raw, "{\"name\":\"Alice\",\"age\":30,\"active\":true,\"nickname\":null}") == 0);
+
+    cJSON *parsed = cJSON_Parse(raw);
+    assert(parsed != NULL);
+    assert(cJSON_GetObjectItem(parsed, "name") != NULL);
+    assert(strcmp(cJSON_GetObjectItem(parsed, "name")->valuestring, "Alice") == 0);
+    assert(cJSON_GetObjectItem(parsed, "age")->valueint == 30);
+    assert(cJSON_IsTrue(cJSON_GetObjectItem(parsed, "active")));
+    assert(cJSON_IsNull(cJSON_GetObjectItem(parsed, "nickname")));
+    cJSON_Delete(parsed);
+
+    cwist_json_builder_destroy(b);
+}
+
+static void test_json_builder_escaping(void) {
+    printf("test_json_builder_escaping...\n");
+    cwist_json_builder *b = cwist_json_builder_create();
+    assert(b != NULL);
+
+    cwist_json_begin_object(b);
+    cwist_json_add_string(b, "quote_and_slash", "He said \"hello\" \\ world");
+    cwist_json_add_string(b, "whitespace", "Line1\nLine2\r\tTabbed\b\f");
+    char ctrl_str[4] = {0x01, 0x1f, 0, 0};
+    cwist_json_add_string(b, "control", ctrl_str);
+    cwist_json_end_object(b);
+
+    const char *raw = cwist_json_get_raw(b);
+    assert(raw != NULL);
+
+    cJSON *parsed = cJSON_Parse(raw);
+    assert(parsed != NULL);
+    assert(strcmp(cJSON_GetObjectItem(parsed, "quote_and_slash")->valuestring, "He said \"hello\" \\ world") == 0);
+    assert(strcmp(cJSON_GetObjectItem(parsed, "whitespace")->valuestring, "Line1\nLine2\r\tTabbed\b\f") == 0);
+    assert(cJSON_GetObjectItem(parsed, "control")->valuestring[0] == 0x01);
+    assert((unsigned char)cJSON_GetObjectItem(parsed, "control")->valuestring[1] == 0x1f);
+    cJSON_Delete(parsed);
+
+    cwist_json_builder_destroy(b);
+}
+
+static void test_json_builder_array_and_null_value(void) {
+    printf("test_json_builder_array_and_null_value...\n");
+    cwist_json_builder *b = cwist_json_builder_create();
+    assert(b != NULL);
+
+    cwist_json_begin_object(b);
+    cwist_json_add_string(b, "null_str", NULL);
+    cwist_json_begin_array(b, "items");
+    cwist_json_add_string(b, NULL, "first");
+    cwist_json_add_int(b, NULL, 42);
+    cwist_json_add_bool(b, NULL, false);
+    cwist_json_add_null(b, NULL);
+    cwist_json_end_array(b);
+    cwist_json_end_object(b);
+
+    const char *raw = cwist_json_get_raw(b);
+    assert(raw != NULL);
+    assert(strcmp(raw, "{\"null_str\":null,\"items\":[\"first\",42,false,null]}") == 0);
+
+    cJSON *parsed = cJSON_Parse(raw);
+    assert(parsed != NULL);
+    assert(cJSON_IsNull(cJSON_GetObjectItem(parsed, "null_str")));
+    cJSON *items = cJSON_GetObjectItem(parsed, "items");
+    assert(cJSON_IsArray(items));
+    assert(cJSON_GetArraySize(items) == 4);
+    cJSON_Delete(parsed);
+
+    cwist_json_builder_destroy(b);
+}
+
+int main(void) {
+    test_json_builder_null_guards();
+    test_json_builder_basic();
+    test_json_builder_escaping();
+    test_json_builder_array_and_null_value();
+    printf("All test_json_builder tests passed!\n");
+    return 0;
+}


### PR DESCRIPTION
### Summary of Changes
1. **RFC 8259 String Escaping**:
   - Implemented JSON string escaping in `src/core/utils/json_builder.c` via helper `append_json_escaped_str()` for quotes (`\"`), backslashes (`\\`), control characters (`\b`, `\f`, `\n`, `\r`, `\t`), and non-printable control characters `< 0x20` (`\u00XX`).
   - Escaped keys and string values properly in objects and arrays.
2. **NULL Safety**:
   - Checked allocation return in `cwist_json_builder_create()` for `b->buffer`.
   - Guarded against NULL `b` and NULL `b->buffer` across all `cwist_json_*` functions.
   - Handled NULL string values by emitting JSON literal `null` instead of crashing on `strlen`/append.
   - Handled NULL array elements cleanly.
3. **Unit Tests**:
   - Added comprehensive tests in `tests/test_json_builder.c` verifying NULL guards, basic formatting, special character escaping, and parsing validation with `cJSON`.
   - Added `test_json_builder` target to `Makefile`.

### Testing
- `make test_json_builder` passes cleanly with zero errors/leaks.
