### PR TITLE
fix(error): zero-initialize cwist_error_t in make_error

### DIFF
--- a/src/sys/err/error.c
+++ b/src/sys/err/error.c
@@ -1,4 +1,5 @@
 #include <cwist/sys/err/cwist_err.h>
+#include <string.h>
 
 /**
  * @file error.c
@@ -12,6 +13,7 @@
  */
 cwist_error_t make_error(cwist_errtype_t type) {
     cwist_error_t err;
+    memset(&err, 0, sizeof(err));
     err.errtype = type;
     return err;
 }

--- a/tests/test_error.c
+++ b/tests/test_error.c
@@ -1,0 +1,46 @@
+/**
+ * @file test_error.c
+ * @brief Unit tests for make_error zero-initialization and error handling.
+ */
+
+#include <cwist/sys/err/cwist_err.h>
+#include <cjson/cJSON.h>
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+
+static void test_make_error_zero_init(void) {
+    printf("test_make_error_zero_init...\n");
+    cwist_error_t err = make_error(CWIST_ERR_INT32);
+    assert(err.errtype == CWIST_ERR_INT32);
+    assert(err.error.err_i32 == 0);
+    assert(cwist_error_is_ok(&err));
+
+    cwist_error_t err_json = make_error(CWIST_ERR_JSON);
+    assert(err_json.errtype == CWIST_ERR_JSON);
+    assert(err_json.error.err_json == NULL);
+
+    // Should not crash because err_json is safely NULL
+    cwist_error_dispose(&err_json);
+    assert(err_json.error.err_json == NULL);
+}
+
+static void test_error_dispose_cjson(void) {
+    printf("test_error_dispose_cjson...\n");
+    cwist_error_t err = make_error(CWIST_ERR_JSON);
+    err.error.err_json = cJSON_CreateObject();
+    assert(err.error.err_json != NULL);
+
+    cwist_error_dispose(&err);
+    assert(err.error.err_json == NULL);
+
+    // NULL pointer should be ignored
+    cwist_error_dispose(NULL);
+}
+
+int main(void) {
+    test_make_error_zero_init();
+    test_error_dispose_cjson();
+    printf("All test_error tests passed!\n");
+    return 0;
+}


### PR DESCRIPTION
### Summary of Changes
1. **Zero-Initialize `cwist_error_t`**:
   - In `src/sys/err/error.c`, `make_error()` allocated `cwist_error_t err` on the stack without initialization, leaving union members (`err.error`) containing uninitialized stack garbage.
   - If an error with `CWIST_ERR_JSON` (or other pointer/union variants) was created, `err.error.err_json` held garbage. Calling `cwist_error_dispose(&err)` would attempt to free that garbage via `cJSON_Delete()`, triggering undefined behavior or segfaults. Similarly, `cwist_error_is_ok(&err)` checks relied on zero values which were corrupted by stack junk.
   - Added `memset(&err, 0, sizeof(err));` in `make_error()` to ensure clean zero-initialization of all fields.
2. **Unit Tests**:
   - Added `tests/test_error.c` verifying zero-initialization across error variants, clean disposal without crashes, and valid JSON disposal.

### Testing
- Tested and verified with GCC under Linux.
