### PR TITLE
fix(arena): prevent integer overflow in cwist_arena_alloc

### DIFF
--- a/src/core/mem/arena.c
+++ b/src/core/mem/arena.c
@@ -43,6 +43,7 @@ cwist_arena_t *cwist_arena_create(size_t generation_bytes) {
 
 void *cwist_arena_alloc(cwist_arena_t *arena, size_t size) {
     if (!arena || !size || !arena->base) return NULL;
+    if (size > SIZE_MAX - 15u) return NULL;
     size = (size + 15u) & ~15u;
     if (size > arena->capacity - arena->used) return NULL;
     void *ptr = arena->base + arena->used;
@@ -215,6 +216,7 @@ void *cwist_arena_alloc(cwist_arena_t *arena, size_t size) {
      * ttak_arena_generation_claim avoids its per-claim cache-line padding
      * and scatter offset; exhaustion still returns NULL so callers fall
      * back to the heap exactly as before. */
+    if (size > SIZE_MAX - 15u) return NULL;
     size = (size + 15u) & ~15u;
     if (size > arena->gen.capacity - arena->gen.used) return NULL;
     void *ptr = (uint8_t *)arena->gen.base + arena->gen.used;

--- a/tests/test_arena.c
+++ b/tests/test_arena.c
@@ -1,0 +1,66 @@
+/**
+ * @file test_arena.c
+ * @brief Unit tests for arena allocator including overflow protection and boundaries.
+ */
+
+#include <cwist/core/mem/arena.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <assert.h>
+
+static void test_arena_basic_and_ownership(void) {
+    printf("test_arena_basic_and_ownership...\n");
+    cwist_arena_t *arena = cwist_arena_create(1024);
+    assert(arena != NULL);
+
+    void *p1 = cwist_arena_alloc(arena, 32);
+    assert(p1 != NULL);
+    assert(cwist_arena_owns(arena, p1));
+    assert(((uintptr_t)p1 % 16) == 0);
+
+    void *p2 = cwist_arena_alloc(arena, 64);
+    assert(p2 != NULL);
+    assert(cwist_arena_owns(arena, p2));
+    assert(((uintptr_t)p2 % 16) == 0);
+    assert((char *)p2 >= (char *)p1 + 32);
+
+    char external_buf[64];
+    assert(!cwist_arena_owns(arena, external_buf));
+    assert(!cwist_arena_owns(arena, NULL));
+    assert(!cwist_arena_owns(NULL, p1));
+
+    cwist_arena_destroy(arena);
+}
+
+static void test_arena_overflow_and_exhaustion(void) {
+    printf("test_arena_overflow_and_exhaustion...\n");
+    cwist_arena_t *arena = cwist_arena_create(512);
+    assert(arena != NULL);
+
+    // Integer overflow attempts near SIZE_MAX should return NULL safely
+    assert(cwist_arena_alloc(arena, SIZE_MAX) == NULL);
+    assert(cwist_arena_alloc(arena, SIZE_MAX - 5) == NULL);
+    assert(cwist_arena_alloc(arena, SIZE_MAX - 14) == NULL);
+
+    // Allocating 0 bytes or NULL arena
+    assert(cwist_arena_alloc(arena, 0) == NULL);
+    assert(cwist_arena_alloc(NULL, 10) == NULL);
+
+    // Allocation larger than capacity
+    assert(cwist_arena_alloc(arena, 1024) == NULL);
+
+    // Valid allocation should still succeed after failed attempts
+    void *p = cwist_arena_alloc(arena, 128);
+    assert(p != NULL);
+    assert(cwist_arena_owns(arena, p));
+
+    cwist_arena_destroy(arena);
+}
+
+int main(void) {
+    test_arena_basic_and_ownership();
+    test_arena_overflow_and_exhaustion();
+    printf("All test_arena tests passed!\n");
+    return 0;
+}


### PR DESCRIPTION
### Summary of Changes
1. **Prevent Integer Overflow in `cwist_arena_alloc()`**:
   - In both Emscripten and POSIX implementations of `cwist_arena_alloc()`, `size = (size + 15u) & ~15u;` did not guard against overflow.
   - For values near `SIZE_MAX` (e.g. `size > SIZE_MAX - 15u`), `size + 15u` would wrap around to a small positive integer, bypassing the subsequent capacity check `if (size > arena->gen.capacity - arena->gen.used)` and returning an undersized buffer, causing buffer overflows.
   - Added `if (size > SIZE_MAX - 15u) return NULL;` before the 16-byte alignment calculation in both paths.
2. **Unit Tests**:
   - Added `tests/test_arena.c` testing normal allocation, 16-byte alignment, ownership checks, capacity limits, and overflow attempts near `SIZE_MAX`.

### Testing
- Tested and verified with GCC under Linux.
