### PR TITLE
fix(seq_auth): validate total chunks bound and cleanse session_id on destroy

### DIFF
--- a/src/core/seq/seq_auth.c
+++ b/src/core/seq/seq_auth.c
@@ -32,7 +32,8 @@ static bool seq_auth_chunk_valid(const uint8_t *data, size_t len,
     out->total = read_u16(data + 2);
     out->payload_len = read_u16(data + 4);
     out->chunk_size = read_u16(data + 6);
-    if (!out->seq || !out->total || out->seq > out->total ||
+    if (!out->seq || !out->total || out->total > CWIST_SEQ_MAX_CHUNKS ||
+        out->seq > out->total ||
         !out->payload_len || !out->chunk_size ||
         out->payload_len > out->chunk_size ||
         (out->seq != out->total && out->payload_len != out->chunk_size) ||
@@ -93,6 +94,7 @@ cwist_seq_auth_context_t *cwist_seq_auth_context_create(
 void cwist_seq_auth_context_destroy(cwist_seq_auth_context_t *ctx) {
     if (!ctx) return;
     OPENSSL_cleanse(ctx->key, sizeof(ctx->key));
+    OPENSSL_cleanse(ctx->session_id, sizeof(ctx->session_id));
     pthread_mutex_destroy(&ctx->lock);
     cwist_free(ctx->nonces);
     cwist_free(ctx->completed_ids);

--- a/tests/test_seq_auth.c
+++ b/tests/test_seq_auth.c
@@ -39,6 +39,18 @@ int main(void) {
     assert(!cwist_seq_auth_unwrap(ctx, replay, replay_len, &meta, &chunk));
     cwist_free(wire); cwist_free(tampered); cwist_free(replay);
     cwist_seq_message_free(&split);
+
+    /* Test chunk with total > CWIST_SEQ_MAX_CHUNKS is rejected */
+    uint8_t invalid_chunk[CWIST_SEQ_AUTH_HEADER_SIZE + 4];
+    memset(invalid_chunk, 0, sizeof(invalid_chunk));
+    invalid_chunk[0] = 0; invalid_chunk[1] = 1; /* seq = 1 */
+    uint16_t excessive_total = CWIST_SEQ_MAX_CHUNKS + 1;
+    invalid_chunk[2] = (uint8_t)(excessive_total >> 8);
+    invalid_chunk[3] = (uint8_t)(excessive_total & 0xff);
+    invalid_chunk[4] = 0; invalid_chunk[5] = 4; /* payload_len = 4 */
+    invalid_chunk[6] = 0; invalid_chunk[7] = 4; /* chunk_size = 4 */
+    assert(!cwist_seq_auth_unwrap(ctx, invalid_chunk, sizeof(invalid_chunk), &meta, &chunk));
+
     cwist_seq_auth_context_destroy(ctx);
     puts("Authenticated sequence tests passed.");
     return 0;


### PR DESCRIPTION
### Summary of Changes
1. **Validate `out->total <= CWIST_SEQ_MAX_CHUNKS` in `seq_auth_chunk_valid()`**:
   - `cwist_seq_chunk_parse()` in `src/core/seq/seq.c` enforces that chunk sequence totals do not exceed `CWIST_SEQ_MAX_CHUNKS`.
   - `seq_auth_chunk_valid()` in `src/core/seq/seq_auth.c` was missing this boundary check, permitting chunks with arbitrarily large `out->total` through auth unwrapping.
   - Added `out->total > CWIST_SEQ_MAX_CHUNKS` validation to `seq_auth_chunk_valid()`.
2. **Securely Cleanse Session ID in `cwist_seq_auth_context_destroy()`**:
   - `cwist_seq_auth_context_destroy()` called `OPENSSL_cleanse(ctx->key, ...)` for the key, but left the sensitive `ctx->session_id` in memory before freeing the context.
   - Added `OPENSSL_cleanse(ctx->session_id, sizeof(ctx->session_id));`.
3. **Unit Tests**:
   - Updated `tests/test_seq_auth.c` with a test case verifying that chunks with `total > CWIST_SEQ_MAX_CHUNKS` are rejected by `cwist_seq_auth_unwrap`.

### Testing
- Tested and verified with GCC under Linux.
