### PR TITLE
fix(healthz): reuse inactive probe slots and guard null probe buffer

### DIFF
--- a/src/sys/health/healthz.c
+++ b/src/sys/health/healthz.c
@@ -32,15 +32,29 @@ static int g_entry_count = 0;
 
 bool cwist_healthz_register(const char *name, cwist_health_probe_fn fn, void *ctx) {
     if (!name || !fn) return false;
-    if (g_entry_count >= CWIST_HEALTHZ_MAX_PROBES) return false;
 
+    int first_free_slot = -1;
     for (int i = 0; i < g_entry_count; ++i) {
-        if (g_entries[i].active && strcmp(g_entries[i].name, name) == 0) {
-            g_entries[i].fn = fn;
-            g_entries[i].ctx = ctx;
-            return true;
+        if (g_entries[i].active) {
+            if (strcmp(g_entries[i].name, name) == 0) {
+                g_entries[i].fn = fn;
+                g_entries[i].ctx = ctx;
+                return true;
+            }
+        } else if (first_free_slot == -1) {
+            first_free_slot = i;
         }
     }
+
+    if (first_free_slot != -1) {
+        g_entries[first_free_slot].name   = name;
+        g_entries[first_free_slot].fn     = fn;
+        g_entries[first_free_slot].ctx    = ctx;
+        g_entries[first_free_slot].active = true;
+        return true;
+    }
+
+    if (g_entry_count >= CWIST_HEALTHZ_MAX_PROBES) return false;
 
     g_entries[g_entry_count].name   = name;
     g_entries[g_entry_count].fn     = fn;
@@ -79,10 +93,15 @@ void cwist_healthz_run(cwist_health_probe_t *out_probes,
     size_t count = 0;
     cwist_health_status_t overall = CWIST_HEALTH_OK;
 
-    for (int i = 0; i < g_entry_count && count < max_probes; ++i) {
+    for (int i = 0; i < g_entry_count; ++i) {
         if (!g_entries[i].active) continue;
         cwist_health_probe_t r = g_entries[i].fn(g_entries[i].ctx);
-        out_probes[count++] = r;
+        if (out_probes && count < max_probes) {
+            out_probes[count] = r;
+        }
+        if (!out_probes || count < max_probes) {
+            count++;
+        }
         if (r.status == CWIST_HEALTH_FAIL) overall = CWIST_HEALTH_FAIL;
         else if (r.status == CWIST_HEALTH_DEGRADED && overall == CWIST_HEALTH_OK)
             overall = CWIST_HEALTH_DEGRADED;
@@ -128,6 +147,7 @@ void cwist_app_healthz(cwist_http_response *res) {
         case CWIST_HEALTH_OK:       res->status_code = CWIST_HTTP_OK; break;
         case CWIST_HEALTH_DEGRADED: res->status_code = CWIST_HTTP_SERVICE_UNAVAILABLE; break;
         case CWIST_HEALTH_FAIL:     res->status_code = CWIST_HTTP_SERVICE_UNAVAILABLE; break;
+        default:                    res->status_code = CWIST_HTTP_SERVICE_UNAVAILABLE; break;
     }
     cwist_json_builder_destroy(jb);
 }

--- a/tests/test_healthz.c
+++ b/tests/test_healthz.c
@@ -1,0 +1,106 @@
+/**
+ * @file test_healthz.c
+ * @brief Unit tests for health probe registry, slot reuse, and NULL safety.
+ */
+
+#include <cwist/sys/health/healthz.h>
+#include <cwist/net/http/http.h>
+#include <cwist/core/sstring/sstring.h>
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+
+/* Stub for cwist_http_header_add to avoid linking full net/http subsystem */
+cwist_error_t cwist_http_header_add(cwist_http_header_node **head, const char *key, const char *value) {
+    (void)head; (void)key; (void)value;
+    cwist_error_t err;
+    memset(&err, 0, sizeof(err));
+    err.errtype = CWIST_ERR_INT16;
+    return err;
+}
+
+static cwist_health_probe_t probe_ok(void *ctx) {
+    (void)ctx;
+    return (cwist_health_probe_t){
+        .name = "probe_ok",
+        .status = CWIST_HEALTH_OK,
+        .message = "All good"
+    };
+}
+
+static cwist_health_probe_t probe_fail(void *ctx) {
+    (void)ctx;
+    return (cwist_health_probe_t){
+        .name = "probe_fail",
+        .status = CWIST_HEALTH_FAIL,
+        .message = "Disk full"
+    };
+}
+
+static void test_healthz_basic_and_slot_reuse(void) {
+    printf("test_healthz_basic_and_slot_reuse...\n");
+
+    // Register 16 probes to fill all slots
+    char names[16][16];
+    for (int i = 0; i < 16; ++i) {
+        snprintf(names[i], sizeof(names[i]), "p_%d", i);
+        assert(cwist_healthz_register(names[i], probe_ok, NULL));
+    }
+
+    // 17th probe should fail because table is full
+    assert(!cwist_healthz_register("p_extra", probe_ok, NULL));
+
+    // Unregister one probe
+    cwist_healthz_unregister("p_5");
+
+    // Now registering a new probe should succeed by reusing the inactive slot
+    assert(cwist_healthz_register("p_reused", probe_ok, NULL));
+
+    // Clean up probes for subsequent tests
+    for (int i = 0; i < 16; ++i) {
+        cwist_healthz_unregister(names[i]);
+    }
+    cwist_healthz_unregister("p_reused");
+}
+
+static void test_healthz_null_buffer_and_status(void) {
+    printf("test_healthz_null_buffer_and_status...\n");
+
+    assert(cwist_healthz_register("db", probe_ok, NULL));
+    assert(cwist_healthz_register("storage", probe_fail, NULL));
+
+    // Run with NULL out_probes: should not crash and should return overall status & count
+    size_t count = 0;
+    cwist_health_status_t overall = CWIST_HEALTH_OK;
+    cwist_healthz_run(NULL, 0, &count, &overall);
+    assert(count == 2);
+    assert(overall == CWIST_HEALTH_FAIL);
+
+    // Run with valid out_probes buffer
+    cwist_health_probe_t probes[4];
+    count = 0;
+    overall = CWIST_HEALTH_OK;
+    cwist_healthz_run(probes, 4, &count, &overall);
+    assert(count == 2);
+    assert(overall == CWIST_HEALTH_FAIL);
+
+    // Test cwist_app_healthz response handling
+    cwist_http_response res;
+    memset(&res, 0, sizeof(res));
+    res.body = cwist_sstring_create();
+    cwist_app_healthz(&res);
+    assert(res.status_code == CWIST_HTTP_SERVICE_UNAVAILABLE);
+    assert(res.body != NULL);
+    assert(strstr(res.body->data, "\"status\":\"fail\"") != NULL);
+    cwist_sstring_destroy(res.body);
+
+    cwist_healthz_unregister("db");
+    cwist_healthz_unregister("storage");
+}
+
+int main(void) {
+    test_healthz_basic_and_slot_reuse();
+    test_healthz_null_buffer_and_status();
+    printf("All test_healthz tests passed!\n");
+    return 0;
+}


### PR DESCRIPTION
### Summary of Changes
1. **Reuse Inactive Probe Slots in `cwist_healthz_register()`**:
   - When probes were unregistered via `cwist_healthz_unregister()`, their slots became `active = false`. However, `cwist_healthz_register()` always appended to `g_entry_count` without checking for free inactive slots, permanently preventing any new registrations once 16 probes were registered over the application lifecycle.
   - Added logic to find and reuse the first inactive slot (`!g_entries[i].active`).
2. **NULL Buffer Safety in `cwist_healthz_run()`**:
   - Callers wishing to compute only total probe count and overall status could pass `out_probes = NULL`. Previously, `out_probes[count++] = r;` caused a NULL pointer dereference.
   - Added NULL guard so `out_probes` is only written to when non-NULL and within `max_probes`.
3. **HTTP Status Code Default**:
   - Added `default: res->status_code = CWIST_HTTP_SERVICE_UNAVAILABLE; break;` in `cwist_app_healthz()` to prevent uninitialized status code paths.
4. **Unit Tests**:
   - Added `tests/test_healthz.c` verifying slot saturation, unregistration slot reuse, and NULL output buffer execution.

### Testing
- Tested and verified with GCC under Linux.
