### PR TITLE
fix(ci): isolate benchmark process lifetimes

### DIFF
--- a/.github/workflows/bsd-kqueue-benchmarks.yml
+++ b/.github/workflows/bsd-kqueue-benchmarks.yml
@@ -24,6 +24,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Test benchmark report generation
         run: python3 -m unittest discover -s scripts/ci -p 'test_*.py' -v
+      - name: Test benchmark process isolation
+        run: python3 -m unittest discover -s tests -p 'test_benchmark_session.py' -v
 
   bsd-kqueue:
     name: kqueue tests (macOS)
@@ -277,35 +279,11 @@ jobs:
             TXT=$4
             STAT_TXT=$5
             WAIT=${6:-2}
-
+            THREADS=${7:-12}
+            CONNECTIONS=${8:-400}
             echo "=== Starting $NAME Web Server (Port $PORT) ==="
-            $CMD &
-            PID=$!
-            for i in $(seq 1 $WAIT); do
-              curl -sf http://127.0.0.1:$PORT/ > /dev/null 2>&1 && break
-              sleep 1
-            done
-
-            # Warmup (results discarded)
-            wrk -t12 -c400 -d10s http://127.0.0.1:$PORT/ > /dev/null 2>&1 || true
-
-            # Initial stat (after warmup)
-            BEFORE_CSW=$(ps -o nvcsw=,nivcsw= -p $PID 2>/dev/null | awk '{print $1+$2}')
-            [ -z "$BEFORE_CSW" ] && BEFORE_CSW=0
-
-            wrk -t12 -c400 -d10s -s "$GITHUB_WORKSPACE/scripts/ci/tail_latency.lua" --latency http://127.0.0.1:$PORT/ > $TXT 2>&1 || true
-
-            AFTER_CSW=$(ps -o nvcsw=,nivcsw= -p $PID 2>/dev/null | awk '{print $1+$2}')
-            [ -z "$AFTER_CSW" ] && AFTER_CSW=0
-            RSS=$(ps -o rss= -p $PID 2>/dev/null | awk '{print $1}')
-            [ -z "$RSS" ] && RSS=0
-
-            CSW=$((AFTER_CSW - BEFORE_CSW))
-            [ $CSW -lt 0 ] && CSW=0
-
-            kill -9 $PID || true
-            echo "rss_kib=$RSS csw=$CSW" > $STAT_TXT
-            cat $TXT
+            python3 "$GITHUB_WORKSPACE/scripts/ci/benchmark_session.py" --server "$CMD" -- \
+              bash "$GITHUB_WORKSPACE/scripts/ci/benchmark_workload.sh" "$PORT" "$TXT" "$STAT_TXT" "$WAIT" "$THREADS" "$CONNECTIONS"
           }
 
           # CWIST is measured twice: the classic thread-pool path (the
@@ -325,17 +303,7 @@ jobs:
           # Tuned low-latency profile (CWIST classic only): lower connection
           # pressure (c100, 4 wrk threads) so the per-request latency floor is
           # visible alongside the c400 throughput numbers.
-          echo "=== Starting CWIST tuned run (wrk -t4 -c100) ==="
-          env CWIST_C1M_MODE=0 /tmp/cwist_server &
-          TUNED_PID=$!
-          for i in $(seq 1 10); do
-            curl -sf http://127.0.0.1:9091/ > /dev/null 2>&1 && break
-            sleep 1
-          done
-          wrk -t4 -c100 -d10s http://127.0.0.1:9091/ > /dev/null 2>&1 || true
-          wrk -t4 -c100 -d10s -s "$GITHUB_WORKSPACE/scripts/ci/tail_latency.lua" --latency http://127.0.0.1:9091/ > /tmp/cwist_tuned.txt 2>&1 || true
-          kill -9 $TUNED_PID || true
-          cat /tmp/cwist_tuned.txt
+          run_bench "CWIST tuned" "env CWIST_C1M_MODE=0 /tmp/cwist_server" 9091 "/tmp/cwist_tuned.txt" "/tmp/cwist_tuned_stat.txt" 10 4 100
           export TUNED_PROFILE="wrk -t4 -c100 -d10s (after 10s warmup, warmup discarded)"
           run_bench "Axum" "/tmp/axum_bench/target/release/axum_server" 9092 "/tmp/axum.txt" "/tmp/axum_stat.txt" 10
           run_bench "Gin" "/tmp/gin_bench/gin_server" 9094 "/tmp/gin.txt" "/tmp/gin_stat.txt" 10
@@ -420,20 +388,9 @@ jobs:
           # the identical treatment: its own dedicated boot (replaying the
           # same trained AOT cache, so it isn't paying a second cold-start
           # penalty CWIST doesn't pay either) measured under -t4 -c100.
-          echo "=== Starting Spring Boot tuned run (wrk -t4 -c100) ==="
-          java $SPRING_JVM_OPTS \
-            -XX:+AOTClassLinking \
-            -XX:AOTCache=$SPRING_AOT_CACHE \
-            -jar /tmp/spring_bench/target/spring-bench-0.0.1-SNAPSHOT.jar --server.port=9093 &
-          SPRING_TUNED_PID=$!
-          for i in $(seq 1 90); do
-            curl -sf http://127.0.0.1:9093/ > /dev/null 2>&1 && break
-            sleep 1
-          done
-          wrk -t4 -c100 -d10s http://127.0.0.1:9093/ > /dev/null 2>&1 || true
-          wrk -t4 -c100 -d10s -s "$GITHUB_WORKSPACE/scripts/ci/tail_latency.lua" --latency http://127.0.0.1:9093/ > /tmp/spring_tuned.txt 2>&1 || true
-          kill -9 $SPRING_TUNED_PID || true
-          cat /tmp/spring_tuned.txt
+          run_bench "Spring Boot tuned" \
+            "java $SPRING_JVM_OPTS -XX:+AOTClassLinking -XX:AOTCache=$SPRING_AOT_CACHE -jar /tmp/spring_bench/target/spring-bench-0.0.1-SNAPSHOT.jar --server.port=9093" \
+            9093 "/tmp/spring_tuned.txt" "/tmp/spring_tuned_stat.txt" 90 4 100
 
           # Result JSON must land in the workspace so upload-artifact can find it
           # (the shell is still sitting in /tmp/spring_bench from the maven build).

--- a/scripts/ci/benchmark_session.py
+++ b/scripts/ci/benchmark_session.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Run one Linux benchmark in private process groups, including its descendants.
+
+Keep leaders unreaped until group cleanup ends, so their numeric PGIDs cannot
+be recycled. This supervises trusted benchmark commands; it is not a sandbox
+for commands that deliberately escape their session. No command/environment
+contents are logged. Requires Linux pidfds and /proc.
+"""
+import argparse
+import math
+import os
+from pathlib import Path
+import select
+import shlex
+import signal
+import subprocess
+import sys
+import time
+
+
+def live_members(pgid):
+    members = []
+    for entry in Path('/proc').iterdir():
+        if not entry.name.isdigit():
+            continue
+        try:
+            fields = (entry / 'stat').read_text().rsplit(') ', 1)[1].split()
+        except (FileNotFoundError, ProcessLookupError):
+            continue
+        if int(fields[2]) == pgid and fields[0] not in ('Z', 'X'):
+            members.append(int(entry.name))
+    return members
+
+
+def send_group(pgid, sig):
+    try:
+        os.killpg(pgid, sig)
+    except ProcessLookupError:
+        pass
+
+
+def stop_group(process, grace):
+    # Do not poll()/wait() on this leader before the last group signal.
+    try:
+        send_group(process.pid, signal.SIGTERM)
+        try:
+            deadline = time.monotonic() + grace
+            while live_members(process.pid) and time.monotonic() < deadline:
+                time.sleep(.02)
+        finally:
+            send_group(process.pid, signal.SIGKILL)
+        deadline = time.monotonic() + 2
+        while live_members(process.pid):
+            if time.monotonic() >= deadline:
+                raise RuntimeError('benchmark group did not stop')
+            time.sleep(.02)
+    finally:
+        process.wait(timeout=2)
+
+
+def positive_seconds(value):
+    parsed = float(value)
+    if not math.isfinite(parsed) or parsed <= 0 or parsed > 600:
+        raise argparse.ArgumentTypeError('must be finite and in (0, 600]')
+    return parsed
+
+
+def finish_status(code, received):
+    # Cleanup is over. Keep terminal handlers until this standalone CLI exits.
+    # Signals during the two-handler handoff are either latched by the old
+    # handler and checked below, or terminate immediately through the new one.
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        signal.signal(sig, lambda number, frame: os._exit(128 + (received[0] if received else number)))
+    return 128 + received[0] if received else code
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--server', required=True)
+    parser.add_argument('--timeout', type=positive_seconds, default=120)
+    parser.add_argument('--grace', type=positive_seconds, default=2)
+    parser.add_argument('command', nargs=argparse.REMAINDER)
+    args = parser.parse_args(argv)
+    command = args.command[1:] if args.command[:1] == ['--'] else args.command
+    server_command = shlex.split(args.server)
+    if not command or not server_command:
+        parser.error('server and workload commands are required')
+    if sys.platform != 'linux' or not hasattr(os, 'pidfd_open'):
+        parser.error('Linux pidfds and /proc are required')
+
+    processes = []
+    received = []
+    reader, writer = os.pipe2(os.O_NONBLOCK | os.O_CLOEXEC)
+    old_wakeup = signal.set_wakeup_fd(writer)
+    old_child_handler = signal.getsignal(signal.SIGCHLD)
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        signal.signal(sig, lambda number, frame: received.append(number))
+    signal.signal(signal.SIGCHLD, signal.SIG_DFL)
+    pidfd = None
+    code = 1
+    cleanup_errors = []
+    try:
+        server = subprocess.Popen(server_command, start_new_session=True)
+        processes.append(server)
+        if not received:
+            env = os.environ.copy()
+            env['BENCHMARK_SERVER_PID'] = str(server.pid)
+            workload = subprocess.Popen(command, env=env, start_new_session=True)
+            processes.append(workload)
+            pidfd = os.pidfd_open(workload.pid)
+            ready, _, _ = select.select([pidfd, reader], [], [], args.timeout)
+            if received:
+                code = 128 + received[0]
+            elif pidfd not in ready:
+                code = 124
+            else:
+                result = os.waitid(os.P_PID, workload.pid, os.WEXITED | os.WNOWAIT)
+                code = result.si_status if result.si_code == os.CLD_EXITED else 128 + result.si_status
+    finally:
+        for process in reversed(processes):
+            try:
+                stop_group(process, args.grace)
+            except Exception as error:
+                cleanup_errors.append(type(error).__name__)
+        if pidfd is not None:
+            os.close(pidfd)
+        signal.set_wakeup_fd(old_wakeup)
+        signal.signal(signal.SIGCHLD, old_child_handler)
+        os.close(reader)
+        os.close(writer)
+        if cleanup_errors:
+            raise RuntimeError('benchmark cleanup failed: ' + ', '.join(cleanup_errors))
+    return finish_status(code, received)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/ci/benchmark_workload.sh
+++ b/scripts/ci/benchmark_workload.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Workload only. benchmark_session.py owns server/descendant cleanup.
+set -eu
+PID=${BENCHMARK_SERVER_PID:?missing supervised server PID}
+PORT=$1
+TXT=$2
+STAT_TXT=$3
+WAIT=$4
+THREADS=$5
+CONNECTIONS=$6
+for i in $(seq 1 $WAIT); do
+  curl -sf http://127.0.0.1:$PORT/ > /dev/null 2>&1 && break
+  sleep 1
+done
+
+# Warmup (results discarded)
+wrk -t"$THREADS" -c"$CONNECTIONS" -d10s http://127.0.0.1:$PORT/ > /dev/null 2>&1 || true
+
+# Initial stat (after warmup)
+BEFORE_CSW=$(ps -o nvcsw=,nivcsw= -p $PID 2>/dev/null | awk '{print $1+$2}')
+[ -z "$BEFORE_CSW" ] && BEFORE_CSW=0
+
+wrk -t"$THREADS" -c"$CONNECTIONS" -d10s -s "$GITHUB_WORKSPACE/scripts/ci/tail_latency.lua" --latency http://127.0.0.1:$PORT/ > $TXT 2>&1 || true
+
+AFTER_CSW=$(ps -o nvcsw=,nivcsw= -p $PID 2>/dev/null | awk '{print $1+$2}')
+[ -z "$AFTER_CSW" ] && AFTER_CSW=0
+RSS=$(ps -o rss= -p $PID 2>/dev/null | awk '{print $1}')
+[ -z "$RSS" ] && RSS=0
+
+CSW=$((AFTER_CSW - BEFORE_CSW))
+[ $CSW -lt 0 ] && CSW=0
+
+echo "rss_kib=$RSS csw=$CSW" > $STAT_TXT
+cat $TXT

--- a/tests/test_benchmark_session.py
+++ b/tests/test_benchmark_session.py
@@ -1,0 +1,179 @@
+"""Linux integration tests: process groups must not leak between benchmarks."""
+import os
+from pathlib import Path
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+
+RUNNER = Path(__file__).resolve().parents[1] / 'scripts/ci/benchmark_session.py'
+SERVER = '''import os,pathlib,signal,time,sys
+pid=os.fork()
+if pid:
+    sys.exit(0)
+p=pathlib.Path(sys.argv[1])
+def publish(path,value):
+    temp=path.with_name(path.name+'.tmp')
+    temp.write_text(value)
+    temp.replace(path)
+def term(signum,frame):
+    publish(p.with_suffix('.cleanup'),'ready')
+signal.signal(signal.SIGTERM,term)
+publish(p,str(os.getpid()))
+time.sleep(30)
+'''
+WORK = '''import os,pathlib,signal,sys,time
+p=pathlib.Path(sys.argv[1])
+end=time.monotonic()+5
+while not p.exists():
+    if time.monotonic()>end:sys.exit(9)
+    time.sleep(.01)
+if sys.argv[2] in ('sleep','orphan'):
+    pid=os.fork()
+    if not pid:
+        signal.signal(signal.SIGTERM,signal.SIG_IGN)
+        p.with_suffix('.work').write_text(str(os.getpid()))
+        time.sleep(30)
+        sys.exit(0)
+    while not p.with_suffix('.work').exists():time.sleep(.01)
+    if sys.argv[2]=='sleep':time.sleep(30)
+    sys.exit(0)
+else:sys.exit(int(sys.argv[2]))
+'''
+
+
+def alive(pid):
+    try:
+        state=Path(f'/proc/{pid}/stat').read_text().rsplit(') ',1)[1].split()[0]
+        return state not in ('Z','X')
+    except FileNotFoundError:
+        return False
+
+
+@unittest.skipUnless(sys.platform == 'linux', 'Linux process-group contract')
+class SessionTests(unittest.TestCase):
+    def run_case(self, mode, timeout: float = 8, terminate=False,
+                 signal_phase='workload', signal_number=signal.SIGTERM):
+        with tempfile.TemporaryDirectory() as directory:
+            root=Path(directory)
+            server=root/'server.py';server.write_text(SERVER)
+            work=root/'work.py';work.write_text(WORK)
+            pidfile=root/'child.pid'
+            grace='1' if signal_phase=='cleanup' else '0.1'
+            args=[sys.executable,str(RUNNER),'--grace',grace,'--timeout',str(timeout),
+                  '--server',f'{sys.executable} {server} {pidfile}',
+                  '--',sys.executable,str(work),str(pidfile),mode]
+            with (root/'log').open('w+') as log:
+                process=subprocess.Popen(args,stdout=log,stderr=log)
+                try:
+                    if terminate:
+                        deadline=time.monotonic()+5
+                        marker=pidfile.with_suffix('.cleanup' if signal_phase=='cleanup' else '.work')
+                        while not marker.exists() and process.poll() is None:
+                            self.assertLess(time.monotonic(),deadline)
+                            time.sleep(.01)
+                        self.assertTrue(marker.exists())
+                        process.send_signal(signal_number)
+                    code=process.wait(timeout=12)
+                    log.seek(0);output=log.read()
+                    self.assertTrue(pidfile.exists(),output)
+                    pid=int(pidfile.read_text())
+                    self.assertFalse(alive(pid),f'worker {pid} survived: {output}')
+                    if mode in ('sleep', 'orphan'):
+                        self.assertTrue(pidfile.with_suffix('.work').exists(), output)
+                        self.assertFalse(alive(int(pidfile.with_suffix('.work').read_text())), output)
+                    return code
+                finally:
+                    if process.poll() is None:
+                        process.kill();process.wait()
+                    # Test-fixture recovery only, never used to satisfy assertions.
+                    for marker, owner in ((pidfile, server), (pidfile.with_suffix('.work'), work)):
+                        if not marker.exists():
+                            continue
+                        pid=int(marker.read_text())
+                        if alive(pid):
+                            handle = os.pidfd_open(pid)
+                            try:
+                                argv = Path(f'/proc/{pid}/cmdline').read_bytes().split(b'\0')
+                                if os.fsencode(owner) in argv:
+                                    signal.pidfd_send_signal(handle, signal.SIGKILL)
+                            finally:
+                                os.close(handle)
+
+    def test_early_server_exit_does_not_leak_child(self):
+        self.assertEqual(self.run_case('0'),0)
+
+    def test_workload_failure_is_preserved(self):
+        self.assertEqual(self.run_case('7'),7)
+
+    def test_workload_early_exit_does_not_leak_child(self):
+        self.assertEqual(self.run_case('orphan'),0)
+
+    def test_timeout_cleans_server(self):
+        self.assertEqual(self.run_case('sleep',timeout=.5),124)
+
+    def test_sigterm_cleans_server(self):
+        self.assertEqual(self.run_case('sleep',terminate=True),143)
+
+    def test_unrelated_group_is_not_signalled(self):
+        other=subprocess.Popen([sys.executable,'-c','import time;time.sleep(30)'],start_new_session=True)
+        try:
+            self.assertEqual(self.run_case('0'),0)
+            self.assertIsNone(other.poll())
+        finally:
+            other.terminate();other.wait(timeout=5)
+
+    def test_sigterm_during_cleanup_is_not_success(self):
+        self.assertEqual(self.run_case('0',terminate=True,signal_phase='cleanup'),143)
+
+    def test_sigint_during_cleanup_is_not_success(self):
+        self.assertEqual(self.run_case('0',terminate=True,signal_phase='cleanup',
+                                      signal_number=signal.SIGINT),130)
+
+
+    def test_final_handler_handoff_preserves_cancellation(self):
+        code = '''import importlib.util,os,signal,sys
+spec=importlib.util.spec_from_file_location("session",sys.argv[1])
+module=importlib.util.module_from_spec(spec);spec.loader.exec_module(module)
+received=[]
+real=signal.signal
+real(signal.SIGINT,lambda number,frame:received.append(number))
+real(signal.SIGTERM,lambda number,frame:received.append(number))
+def install(number,handler):
+    result=real(number,handler)
+    if number==signal.SIGINT:os.kill(os.getpid(),signal.SIGTERM)
+    return result
+signal.signal=install
+sys.exit(module.finish_status(0,received))
+'''
+        result=subprocess.run([sys.executable,'-c',code,str(RUNNER)],timeout=5)
+        self.assertEqual(result.returncode,143)
+
+    def test_signal_after_final_status_is_not_success(self):
+        code = '''import importlib.util,os,signal,sys
+spec=importlib.util.spec_from_file_location("session",sys.argv[1])
+module=importlib.util.module_from_spec(spec);spec.loader.exec_module(module)
+status=module.finish_status(0,[])
+os.kill(os.getpid(),signal.SIGTERM)
+sys.exit(status)
+'''
+        result=subprocess.run([sys.executable,'-c',code,str(RUNNER)],timeout=5)
+        self.assertEqual(result.returncode,143)
+
+
+    def test_first_signal_remains_authoritative(self):
+        code = '''import importlib.util,os,signal,sys
+spec=importlib.util.spec_from_file_location("session",sys.argv[1])
+module=importlib.util.module_from_spec(spec);spec.loader.exec_module(module)
+status=module.finish_status(0,[signal.SIGINT])
+os.kill(os.getpid(),signal.SIGTERM)
+sys.exit(status)
+'''
+        result=subprocess.run([sys.executable,'-c',code,str(RUNNER)],timeout=5)
+        self.assertEqual(result.returncode,130)
+
+
+if __name__=='__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Related to #25. This repairs benchmark isolation; it does not claim a runtime P99.999 improvement.

The existing `run_bench` ends each profile with `kill -9 $PID`. CWIST forks worker processes. Killing only their parent leaves workers listening on the reused port. A later C1M profile can therefore share its port with surviving classic workers.

### Reproduced with the real CWIST server

With four workers:

- Start classic: four listening processes.
- Apply the current parent-only SIGKILL: three workers remain, and HTTP requests still return 200.
- Start C1M on the same port: three old classic workers plus four new C1M workers are listening.
- The reproduction cleaned up every owned process afterwards.

This proves the isolation defect. It does not reconstruct how many requests in a historical CI run reached each old worker.

## Change

- Start each server and workload in separate private process groups.
- Keep both leaders unreaped until all group signals finish, preventing numeric PGID reuse during cleanup.
- Clean both groups on completion, command failure, timeout, SIGINT, and SIGTERM.
- Bound TERM/KILL cleanup and reject remaining live group members.
- Apply the same supervision to normal and tuned profiles.
- Retain existing workload arguments, warmup, result filenames, and percentile reporting.

The helper is Linux-only, matching the web-server job. It supervises trusted benchmark commands, not programs that deliberately escape their session. Uncatchable termination of the supervisor remains outside its cleanup guarantees.

## Verification

- Eleven Linux integration tests pass normally and with `python3 -O`.
- Cleanup-phase TERM/INT and handler-handoff regressions ensure cancellation cannot be reported as success.
- Covered early server/workload exit with live children, TERM-resistant children, workload failure, timeout, cancellation, and an unrelated process group.
- Real-server GREEN: classic then C1M, four processes each, ten HTTP 200 responses per phase; no live group members or open port after either phase.
- Extracted workflow function smoke test uses real CWIST and a stub load command. It verifies `-t12 -c400 -d10s` and tuned `-t4 -c100 -d10s` argument preservation and cleanup. This smoke test is not a performance benchmark.
- Eleven existing benchmark-renderer tests pass.
- YAML parsing and Bash syntax checks pass.
- Full native-x86 benchmark results are pending this PR's CI. Historical mixed-profile values should not be treated as an isolated baseline for the corrected runs.

## Kept separate

This change does not repair the legacy root-only `ps` statistics or the workload's existing `wrk` error suppression. Neither should be used as proof of error-free or complete scheduling telemetry. No application defaults or latency thresholds change.
