### PR TITLE
fix(sstring): prevent overflow in substr and normalize empty string compare

### DIFF
--- a/src/core/sstring/sstring.c
+++ b/src/core/sstring/sstring.c
@@ -235,6 +235,10 @@ size_t cwist_sstring_get_size(cwist_sstring *str) {
     return str ? str->size : 0;
 }
 
+static inline const char *sstring_data_or_empty(const cwist_sstring *s) {
+    return (s && s->data) ? s->data : "";
+}
+
 /**
  * @brief Compare two CWIST string objects using strcmp semantics.
  * @param left Left-hand string.
@@ -242,12 +246,7 @@ size_t cwist_sstring_get_size(cwist_sstring *str) {
  * @return Negative, zero, or positive depending on lexical ordering.
  */
 int cwist_sstring_compare_sstring(cwist_sstring *left, const cwist_sstring *right) {
-    if (!left || !left->data) {
-        if (!right || !right->data) return 0;
-        return -1;
-    }
-    if (!right || !right->data) return 1;
-    return strcmp(left->data, right->data);
+    return strcmp(sstring_data_or_empty(left), sstring_data_or_empty(right));
 }
 
 /**
@@ -739,13 +738,7 @@ void cwist_sstring_destroy(cwist_sstring *str) {
  * @return Negative, zero, or positive depending on lexical ordering.
  */
 int cwist_sstring_compare(cwist_sstring *str, const char *compare_to) {
-    if (!str || !str->data) {
-        if (!compare_to) return 0; // Both NULL-ish (empty treated as NULL for comparison?)
-        return -1; 
-    }
-    if (!compare_to) return 1; 
-    
-    return strcmp(str->data, compare_to);
+    return strcmp(sstring_data_or_empty(str), compare_to ? compare_to : "");
 }
 
 /**
@@ -762,8 +755,8 @@ cwist_sstring *cwist_sstring_substr(cwist_sstring *str, int start, int length) {
     if ((size_t)start >= current_len) return NULL;
     
     // Adjust length if it goes beyond end
-    if ((size_t)(start + length) > current_len) {
-        length = current_len - start;
+    if ((size_t)length > current_len - (size_t)start) {
+        length = (int)(current_len - (size_t)start);
     }
     
     cwist_sstring *sub = cwist_sstring_create();

--- a/src/core/sstring/sstring.c
+++ b/src/core/sstring/sstring.c
@@ -235,7 +235,7 @@ size_t cwist_sstring_get_size(cwist_sstring *str) {
     return str ? str->size : 0;
 }
 
-static inline const char *sstring_data_or_empty(const cwist_sstring *s) {
+static inline const char *sstring_as_text(const cwist_sstring *s) {
     return (s && s->data) ? s->data : "";
 }
 
@@ -246,7 +246,7 @@ static inline const char *sstring_data_or_empty(const cwist_sstring *s) {
  * @return Negative, zero, or positive depending on lexical ordering.
  */
 int cwist_sstring_compare_sstring(cwist_sstring *left, const cwist_sstring *right) {
-    return strcmp(sstring_data_or_empty(left), sstring_data_or_empty(right));
+    return strcmp(sstring_as_text(left), sstring_as_text(right));
 }
 
 /**
@@ -738,7 +738,7 @@ void cwist_sstring_destroy(cwist_sstring *str) {
  * @return Negative, zero, or positive depending on lexical ordering.
  */
 int cwist_sstring_compare(cwist_sstring *str, const char *compare_to) {
-    return strcmp(sstring_data_or_empty(str), compare_to ? compare_to : "");
+    return strcmp(sstring_as_text(str), compare_to ? compare_to : "");
 }
 
 /**

--- a/tests/test_sstring.c
+++ b/tests/test_sstring.c
@@ -107,6 +107,17 @@ void test_compare() {
     assert(cwist_sstring_compare(s, "he") > 0);
     assert(cwist_sstring_compare(s, "hello world") < 0);
     
+    /* Empty sstring comparisons */
+    cwist_sstring *empty_new = cwist_sstring_create();
+    cwist_sstring *empty_assigned = cwist_sstring_create();
+    cwist_sstring_assign(empty_assigned, "");
+    assert(cwist_sstring_compare_sstring(empty_new, empty_assigned) == 0);
+    assert(cwist_sstring_compare(empty_new, "") == 0);
+    assert(cwist_sstring_compare(empty_new, NULL) == 0);
+    assert(cwist_sstring_compare(empty_assigned, NULL) == 0);
+    cwist_sstring_destroy(empty_new);
+    cwist_sstring_destroy(empty_assigned);
+
     cwist_sstring_destroy(s);
     printf("Passed compare.\n");
 }
@@ -124,6 +135,12 @@ void test_substr() {
     sub = cwist_sstring_substr(s, 8, 5); // "89" (capped)
     assert(sub != NULL);
     assert(strcmp(sub->data, "89") == 0);
+    cwist_sstring_destroy(sub);
+
+    /* Test INT_MAX length safely capped without signed integer overflow */
+    sub = cwist_sstring_substr(s, 2, 2147483647);
+    assert(sub != NULL);
+    assert(strcmp(sub->data, "23456789") == 0);
     cwist_sstring_destroy(sub);
     
     sub = cwist_sstring_substr(s, 10, 1); // Out of bounds


### PR DESCRIPTION
### Summary of Changes
1. **Prevent Signed Integer Overflow in `cwist_sstring_substr()`**:
   - In `src/core/sstring/sstring.c`, `if ((size_t)(start + length) > current_len)` caused signed 32-bit integer overflow (undefined behavior) when `length` was large (e.g. `INT_MAX`).
   - Replaced with `if ((size_t)length > current_len - (size_t)start)` which avoids addition and bounds `length` safely.
2. **Normalize Empty String Comparisons in `cwist_sstring_compare_sstring()`**:
   - A newly created string initialized with `cwist_sstring_create()` has `data == NULL`, while an empty string assigned `""` has `data != NULL` with `data[0] == '\0'`.
   - Comparing these two empty string instances previously returned non-zero (`-1` or `1`), erroneously treating two empty strings as unequal.
   - Normalized both NULL data and empty string data to `""` via `sstring_data_or_empty()` so all empty string representations compare symmetrically and equally (`0`).
3. **Unit Tests**:
   - Added unit test cases to `tests/test_sstring.c` for empty string comparisons (`empty_new` vs `empty_assigned` vs `""` vs `NULL`) and `INT_MAX` length substring extraction.

### Testing
- Tested and verified with GCC under Linux.
