### PR TITLE
fix(writer_fast): add null check and seed safeguard in cwist_sched_p2c_select_worker

### DIFF
--- a/src/net/http/writer_fast.c
+++ b/src/net/http/writer_fast.c
@@ -85,11 +85,12 @@ cwist_write_status_t cwist_http_sendmsg_speculative(int fd, struct iovec *iov, i
 }
 
 uint32_t cwist_sched_p2c_select_worker(const _Atomic uint32_t *worker_loads, uint32_t num_workers) {
-    if (num_workers <= 1) return 0;
+    if (!worker_loads || num_workers <= 1) return 0;
 
     static _Thread_local uint32_t seed = 0x9e3779b9;
     if (__builtin_expect(seed == 0, 0)) {
         seed = (uint32_t)(uintptr_t)&seed;
+        if (seed == 0) seed = 0x9e3779b9;
     }
 
     /* Fast xorshift32 PRNG */

--- a/tests/test_linux_writer_fast.c
+++ b/tests/test_linux_writer_fast.c
@@ -27,6 +27,12 @@ static void test_p2c_scheduler(void) {
     assert(counts[2] > counts[0]);
     assert(counts[2] > counts[1]);
     assert(counts[2] > counts[3]);
+
+    /* Null and boundary guards */
+    assert(cwist_sched_p2c_select_worker(NULL, 4) == 0);
+    assert(cwist_sched_p2c_select_worker(NULL, 0) == 0);
+    assert(cwist_sched_p2c_select_worker(loads, 0) == 0);
+    assert(cwist_sched_p2c_select_worker(loads, 1) == 0);
     printf("OK\n");
 }
 


### PR DESCRIPTION
### Summary of Changes
1. **NULL and Boundary Checks in `cwist_sched_p2c_select_worker()`**:
   - `cwist_sched_p2c_select_worker()` in `src/net/http/writer_fast.c` checked `if (num_workers <= 1) return 0;`, but never checked if `worker_loads` was NULL.
   - If called with `num_workers > 1` and `worker_loads == NULL`, `atomic_load_explicit(&worker_loads[w1], ...)` resulted in a segmentation fault.
   - Added `if (!worker_loads || num_workers <= 1) return 0;` to ensure safe operation.
2. **PRNG Seed Safeguard**:
   - If `(uint32_t)(uintptr_t)&seed` evaluates to 0, ensure `seed` falls back to `0x9e3779b9` rather than remaining 0 (which causes xorshift to loop on 0).
3. **Unit Tests**:
   - Updated `tests/test_linux_writer_fast.c` with test assertions verifying NULL `worker_loads`, 0 workers, and 1 worker safely return 0 without errors or crashes.

### Testing
- Tested and verified with GCC under Linux.
